### PR TITLE
WIP update for LWJGL 3.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,3 @@ bin/
 # fabric
 
 run/
-
-# avoid bad open
-
-.vs/
-.vc/

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ bin/
 # fabric
 
 run/
+
+# avoid bad open
+
+.vs/
+.vc/

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
-project.ext.lwjglVersion = "3.2.3"
+project.ext.lwjglVersion = "3.3.0"
 project.ext.jomlVersion = "1.10.4"
 project.ext.winNatives = "natives-windows"
 project.ext.linuxNatives = "natives-linux"

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
-project.ext.lwjglVersion = "3.3.0"
+project.ext.lwjglVersion = "3.3.0" // needs to be save 3.2.3?!
 project.ext.jomlVersion = "1.10.4"
 project.ext.winNatives = "natives-windows"
 project.ext.linuxNatives = "natives-linux"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,16 +1,16 @@
 # Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx1G
+org.gradle.jvmargs=-Xmx8G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
 	minecraft_version=1.18.2
-	yarn_mappings=1.18.2+build.1
-	loader_version=0.13.3
+	yarn_mappings=1.18.2+build.3
+	loader_version=0.14.5
 
 # Mod Properties
 	mod_version = 0.1.4+1
-	maven_group = com.example
+	maven_group = net.vulkanmod
 	archives_base_name = VulkanMod_1.18
 
-# Dependencies
-	fabric_version=0.47.8+1.18.2
+#Fabric api
+	fabric_version=0.51.1+1.18.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,16 +1,16 @@
 # Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx4G
+org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-	# check these on https://fabricmc.net/develop
-	minecraft_version=1.18.2
-	yarn_mappings=1.18.2+build.3
-	loader_version=0.14.5
+# check these on https://fabricmc.net/develop
+minecraft_version=1.18.2
+yarn_mappings=1.18.2+build.1
+loader_version=0.13.3
 
 # Mod Properties
-	mod_version = 0.1.4+1
-	maven_group = net.vulkanmod
-	archives_base_name = VulkanMod_1.18
+mod_version = 0.1.4+1
+maven_group = com.example
+archives_base_name = VulkanMod_1.18
 
-#Fabric api
-	fabric_version=0.51.1+1.18.2
+# Dependencies
+fabric_version=0.47.8+1.18.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx8G
+org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop

--- a/src/main/java/net/vulkanmod/mixin/renderer/BufferBuilderM.java
+++ b/src/main/java/net/vulkanmod/mixin/renderer/BufferBuilderM.java
@@ -7,7 +7,7 @@ import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(BufferBuilder.class)
 public abstract class BufferBuilderM extends FixedColorVertexConsumer implements BufferVertexConsumer{
-
+    private static boolean useFloat = false;
 
     @Shadow private boolean textured;
 
@@ -26,63 +26,65 @@ public abstract class BufferBuilderM extends FixedColorVertexConsumer implements
     /**
      * @author
      */
-    /*
     @Overwrite
     public VertexConsumer color(int red, int green, int blue, int alpha) {
         VertexFormatElement vertexFormatElement = this.getCurrentElement();
         if (vertexFormatElement.getType() != VertexFormatElement.Type.COLOR) {
             return this;
         }
-        if (vertexFormatElement.getDataType() != VertexFormatElement.DataType.FLOAT || vertexFormatElement.getLength() != 4) {
-            throw new IllegalStateException();
+        //if (vertexFormatElement.getDataType() != VertexFormatElement.DataType.FLOAT || vertexFormatElement.getLength() != 4) {
+            //throw new IllegalStateException();
+        //}
+        if (vertexFormatElement.getDataType()  == VertexFormatElement.DataType.FLOAT) {
+            this.putFloat(0, red / 255.0F);
+            this.putFloat(4, green / 255.0F);
+            this.putFloat(8, blue / 255.0F);
+            this.putFloat(12, alpha / 255.0F);
+        } else {
+            this.putByte(0, (byte)red );
+            this.putByte(1, (byte)green);
+            this.putByte(2, (byte)blue);
+            this.putByte(3, (byte)alpha);
         }
-        this.putFloat(0, red / 255.0F);
-        this.putFloat(4, green / 255.0F);
-        this.putFloat(8, blue / 255.0F);
-        this.putFloat(12, alpha / 255.0F);
         this.nextElement();
         return this;
-    }*/
+    }
 
     /**
      * @author
      */
-    /*@Overwrite
+    @Overwrite
     public void vertex(float x, float y, float z, float red, float green, float blue, float alpha, float u, float v, int overlay, int light, float normalX, float normalY, float normalZ) {
         if (this.colorFixed) {
             throw new IllegalStateException();
         }
         if (this.textured) {
-            int i;
             this.putFloat(0, x);
             this.putFloat(4, y);
             this.putFloat(8, z);
-//            this.putByte(12, (byte)(red * 255.0f));
-//            this.putByte(13, (byte)(green * 255.0f));
-//            this.putByte(14, (byte)(blue * 255.0f));
-//            this.putByte(15, (byte)(alpha * 255.0f));
-//            this.putFloat(16, u);
-//            this.putFloat(20, v);
-//            if (this.hasOverlay) {
-//                this.putShort(24, (short)(overlay & 0xFFFF));
-//                this.putShort(26, (short)(overlay >> 16 & 0xFFFF));
-//                i = 28;
-//            } else {
-//                i = 24;
-//            }
+            int i = 12;
 
-            this.putFloat(12, red);
-            this.putFloat(16, green);
-            this.putFloat(20, blue);
-            this.putFloat(24, alpha);
-            this.putFloat(28, u);
-            this.putFloat(32, v);
-            if (this.hasOverlay) {
-                this.putShort(36, (short)(overlay & '\uffff'));
-                this.putShort(38, (short)(overlay >> 16 & '\uffff'));
-                i = 40;
+            if (useFloat) {
+                this.putFloat(i+0, red);
+                this.putFloat(i+4, green);
+                this.putFloat(i+8, blue);
+                this.putFloat(i+12, alpha);
+                i+=16;
             } else {
-                i = 36;
+                this.putByte(i+0, (byte) (red*255.f));
+                this.putByte(i+1, (byte) (green*255.f));
+                this.putByte(i+2, (byte) (blue*255.f));
+                this.putByte(i+3, (byte) (alpha*255.f));
+                i+=4;
+            }
+            this.putFloat(i, u);
+            this.putFloat(i+4, v);
+            i+=8;
+            if (this.hasOverlay) {
+                this.putShort(i, (short)(overlay & '\uffff'));
+                this.putShort(i+2, (short)(overlay >> 16 & '\uffff'));
+                i+=4;
+            } else {
             }
 
             this.putShort(i + 0, (short)(light & (LightmapTextureManager.MAX_BLOCK_LIGHT_COORDINATE | 0xFF0F)));
@@ -95,5 +97,5 @@ public abstract class BufferBuilderM extends FixedColorVertexConsumer implements
             return;
         }
         super.vertex(x, y, z, red, green, blue, alpha, u, v, overlay, light, normalX, normalY, normalZ);
-    }*/
+    }
 }

--- a/src/main/java/net/vulkanmod/mixin/renderer/BufferBuilderM.java
+++ b/src/main/java/net/vulkanmod/mixin/renderer/BufferBuilderM.java
@@ -26,6 +26,7 @@ public abstract class BufferBuilderM extends FixedColorVertexConsumer implements
     /**
      * @author
      */
+    /*
     @Overwrite
     public VertexConsumer color(int red, int green, int blue, int alpha) {
         VertexFormatElement vertexFormatElement = this.getCurrentElement();
@@ -41,12 +42,12 @@ public abstract class BufferBuilderM extends FixedColorVertexConsumer implements
         this.putFloat(12, alpha / 255.0F);
         this.nextElement();
         return this;
-    }
+    }*/
 
     /**
      * @author
      */
-    @Overwrite
+    /*@Overwrite
     public void vertex(float x, float y, float z, float red, float green, float blue, float alpha, float u, float v, int overlay, int light, float normalX, float normalY, float normalZ) {
         if (this.colorFixed) {
             throw new IllegalStateException();
@@ -94,5 +95,5 @@ public abstract class BufferBuilderM extends FixedColorVertexConsumer implements
             return;
         }
         super.vertex(x, y, z, red, green, blue, alpha, u, v, overlay, light, normalX, normalY, normalZ);
-    }
+    }*/
 }

--- a/src/main/java/net/vulkanmod/mixin/renderer/VertexFormatsM.java
+++ b/src/main/java/net/vulkanmod/mixin/renderer/VertexFormatsM.java
@@ -19,10 +19,11 @@ public class VertexFormatsM {
 //        VertexFormats.COLOR_ELEMENT = new VertexFormatElement(0, VertexFormatElement.DataType.FLOAT, VertexFormatElement.Type.COLOR, 4);
 //    }
 
+    /*
     @Inject(method = "<clinit>",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/VertexFormat;<init>(Lcom/google/common/collect/ImmutableMap;)V", ordinal = 0))
     private static void replaceColor(CallbackInfo ci) {
-        COLOR_ELEMENT = new VertexFormatElement(0, VertexFormatElement.DataType.FLOAT, VertexFormatElement.Type.COLOR, 4);
+        COLOR_ELEMENT = new VertexFormatElement(0, VertexFormatElement.DataType.BYTE, VertexFormatElement.Type.COLOR, 4);
 
-    }
+    }*/
 }

--- a/src/main/java/net/vulkanmod/mixin/renderer/VertexFormatsM.java
+++ b/src/main/java/net/vulkanmod/mixin/renderer/VertexFormatsM.java
@@ -11,6 +11,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(VertexFormats.class)
 public class VertexFormatsM {
 
+    private static boolean useFloat = false;
+
     @Shadow public static VertexFormatElement COLOR_ELEMENT;
 
 //    static {
@@ -19,11 +21,11 @@ public class VertexFormatsM {
 //        VertexFormats.COLOR_ELEMENT = new VertexFormatElement(0, VertexFormatElement.DataType.FLOAT, VertexFormatElement.Type.COLOR, 4);
 //    }
 
-    /*
     @Inject(method = "<clinit>",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/VertexFormat;<init>(Lcom/google/common/collect/ImmutableMap;)V", ordinal = 0))
     private static void replaceColor(CallbackInfo ci) {
-        COLOR_ELEMENT = new VertexFormatElement(0, VertexFormatElement.DataType.BYTE, VertexFormatElement.Type.COLOR, 4);
-
-    }*/
+        if (useFloat) {
+            COLOR_ELEMENT = new VertexFormatElement(0, VertexFormatElement.DataType.FLOAT, VertexFormatElement.Type.COLOR, 4);
+        };
+    }
 }

--- a/src/main/java/net/vulkanmod/vulkan/Pipeline.java
+++ b/src/main/java/net/vulkanmod/vulkan/Pipeline.java
@@ -429,15 +429,11 @@ public class Pipeline {
             }
             else if (format.getType() == VertexFormatElement.Type.COLOR)
             {
-                if (format.getDataType() == VertexFormatElement.DataType.UBYTE) {
-                    posDescription.format(VK_FORMAT_R8G8B8A8_UNORM);
-                } else
-                {
-                    posDescription.format(VK_FORMAT_R32G32B32A32_SFLOAT);
-                }
+                boolean isByte = format.getDataType() == VertexFormatElement.DataType.UBYTE;
+                posDescription.format(isByte ? VK_FORMAT_R8G8B8A8_UNORM : VK_FORMAT_R32G32B32A32_SFLOAT);
                 posDescription.offset(offset);
 
-                offset += 16;
+                offset += isByte ? 4 : 16;
             }
             else if (format.getType() == VertexFormatElement.Type.UV)
             {

--- a/src/main/java/net/vulkanmod/vulkan/Pipeline.java
+++ b/src/main/java/net/vulkanmod/vulkan/Pipeline.java
@@ -419,37 +419,42 @@ public class Pipeline {
             VkVertexInputAttributeDescription posDescription = attributeDescriptions.get(i);
             posDescription.binding(0);
             posDescription.location(i);
-
-            if (elements.get(i).getType() == VertexFormatElement.Type.POSITION)
+            VertexFormatElement format = elements.get(i);
+            if (format.getType() == VertexFormatElement.Type.POSITION)
             {
                 posDescription.format(VK_FORMAT_R32G32B32_SFLOAT);
                 posDescription.offset(offset);
 
                 offset += 12;
             }
-            else if (elements.get(i).getType() == VertexFormatElement.Type.COLOR)
+            else if (format.getType() == VertexFormatElement.Type.COLOR)
             {
-                posDescription.format(VK_FORMAT_R32G32B32A32_SFLOAT);
+                if (format.getDataType() == VertexFormatElement.DataType.UBYTE) {
+                    posDescription.format(VK_FORMAT_R8G8B8A8_UNORM);
+                } else
+                {
+                    posDescription.format(VK_FORMAT_R32G32B32A32_SFLOAT);
+                }
                 posDescription.offset(offset);
 
                 offset += 16;
             }
-            else if (elements.get(i).getType() == VertexFormatElement.Type.UV)
+            else if (format.getType() == VertexFormatElement.Type.UV)
             {
-                if(elements.get(i).getDataType() == VertexFormatElement.DataType.FLOAT){
+                if(format.getDataType() == VertexFormatElement.DataType.FLOAT){
                     posDescription.format(VK_FORMAT_R32G32_SFLOAT);
                     posDescription.offset(offset);
 
                     offset += 8;
                 }
-                else if(elements.get(i).getDataType() == VertexFormatElement.DataType.SHORT){
+                else if(format.getDataType() == VertexFormatElement.DataType.SHORT){
                     posDescription.format(VK_FORMAT_R16G16_SINT);
                     posDescription.offset(offset);
 
                     offset += 4;
                 }
             }
-            else if (elements.get(i).getType() == VertexFormatElement.Type.NORMAL)
+            else if (format.getType() == VertexFormatElement.Type.NORMAL)
             {
                 posDescription.format(VK_FORMAT_R8G8B8_SNORM);
                 //posDescription.format(VK_FORMAT_R32G32B32_SFLOAT);
@@ -457,7 +462,7 @@ public class Pipeline {
 
                 offset += 3;
             }
-            else if (elements.get(i).getType() == VertexFormatElement.Type.PADDING)
+            else if (format.getType() == VertexFormatElement.Type.PADDING)
             {
                 posDescription.format(VK_FORMAT_R8_UNORM);
                 posDescription.offset(offset);

--- a/src/main/java/net/vulkanmod/vulkan/Vulkan.java
+++ b/src/main/java/net/vulkanmod/vulkan/Vulkan.java
@@ -435,8 +435,10 @@ public class Vulkan {
             VmaAllocatorCreateInfo allocatorCreateInfo = VmaAllocatorCreateInfo.callocStack(stack);
             allocatorCreateInfo.physicalDevice(physicalDevice);
             allocatorCreateInfo.device(device);
-            allocatorCreateInfo.instance(instance);
             allocatorCreateInfo.pVulkanFunctions(vulkanFunctions);
+
+            // required for LWJGL 3.3.0
+            allocatorCreateInfo.instance(instance);
 
             PointerBuffer pAllocator = stack.pointers(VK_NULL_HANDLE);
 

--- a/src/main/java/net/vulkanmod/vulkan/Vulkan.java
+++ b/src/main/java/net/vulkanmod/vulkan/Vulkan.java
@@ -435,9 +435,10 @@ public class Vulkan {
             VmaAllocatorCreateInfo allocatorCreateInfo = VmaAllocatorCreateInfo.callocStack(stack);
             allocatorCreateInfo.physicalDevice(physicalDevice);
             allocatorCreateInfo.device(device);
+            allocatorCreateInfo.instance(instance);
             allocatorCreateInfo.pVulkanFunctions(vulkanFunctions);
 
-            PointerBuffer pAllocator = stack.pointers(VK_NULL_HANDLE);
+            PointerBuffer pAllocator = stack.mallocPointer(1);//stack.pointers(VK_NULL_HANDLE);
 
             if (vmaCreateAllocator(allocatorCreateInfo, pAllocator) != VK_SUCCESS) {
                 throw new RuntimeException("Failed to create command pool");

--- a/src/main/java/net/vulkanmod/vulkan/Vulkan.java
+++ b/src/main/java/net/vulkanmod/vulkan/Vulkan.java
@@ -438,7 +438,7 @@ public class Vulkan {
             allocatorCreateInfo.instance(instance);
             allocatorCreateInfo.pVulkanFunctions(vulkanFunctions);
 
-            PointerBuffer pAllocator = stack.mallocPointer(1);//stack.pointers(VK_NULL_HANDLE);
+            PointerBuffer pAllocator = stack.pointers(VK_NULL_HANDLE);
 
             if (vmaCreateAllocator(allocatorCreateInfo, pAllocator) != VK_SUCCESS) {
                 throw new RuntimeException("Failed to create command pool");


### PR DESCRIPTION
Indigo renderer issue: https://github.com/orgs/FabricMC/discussions/2231 (discussion)
It's works when "you have to set always-tesselate-blocks=false in config/fabric/indigo-renderer.properties"

What I changed: 
- ~~replaced `com.example` to `net.vulkanmod`~~
- ~~update `yarn_mappings=1.18.2+build.3`~~
- ~~update `fabric_version=0.51.1+1.18.2`~~
- ~~update `loader_version=0.14.5`~~
- ~~increased memory `org.gradle.jvmargs=-Xmx4G`~~
- tried `project.ext.lwjglVersion = "3.3.0"`
- fix `allocatorCreateInfo.instance(instance);` in `Vulkan.java`
- ~~avoid `.vs` or `.vc` folder from upload~~
- rise back byte color instead of float, back compatibility with indigo tessellation
