### PR TITLE
Basic frustum changes

### DIFF
--- a/src/main/java/net/vulkanmod/mixin/WorldRendererMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/WorldRendererMixin.java
@@ -1,7 +1,6 @@
 package net.vulkanmod.mixin;
 
 import com.mojang.blaze3d.systems.RenderSystem;
-
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectListIterator;
 import net.minecraft.client.render.*;
@@ -234,8 +233,8 @@ public abstract class WorldRendererMixin {
      * @param frustum
      * @param info
      */
-    @Inject(at = @At("HEAD"), method = "applyFrustum", cancellable = true)
-    private void applyFrustum(Frustum frustum, CallbackInfo info) {
+    @Overwrite
+    private void applyFrustum(Frustum frustum) {
         if(lastFrustum != null && !chunkInfos.isEmpty() && this.field_34817.get().field_34819.size() == potentialChunks) {
             Vector4f viewVector = new Vector4f(frustum.field_34821.getX(), frustum.field_34821.getY(), frustum.field_34821.getZ(), frustum.field_34821.getW());
             viewVector.normalize();
@@ -248,7 +247,6 @@ public abstract class WorldRendererMixin {
                 skip = false;
             }
             if(skip) {
-                info.cancel();
                 return;
             }
         }
@@ -263,7 +261,6 @@ public abstract class WorldRendererMixin {
         lastFrustum = frustum;
         lastFrustum.field_34821.normalize();
         potentialChunks = this.field_34817.get().field_34819.size();
-        info.cancel();
     }
     
 }

--- a/src/main/java/net/vulkanmod/mixin/WorldRendererMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/WorldRendererMixin.java
@@ -27,9 +27,6 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(WorldRenderer.class)
 public abstract class WorldRendererMixin {

--- a/src/main/resources/vulkanmod.accesswidener
+++ b/src/main/resources/vulkanmod.accesswidener
@@ -2,3 +2,8 @@ accessWidener	v1	named
 #Accessible class net/minecraft/client/render/WorldRenderer$ChunkInfo
 Accessible field net/minecraft/client/render/WorldRenderer$ChunkInfo chunk Lnet/minecraft/client/render/chunk/ChunkBuilder$BuiltChunk;
 Mutable field net/minecraft/client/render/VertexFormats COLOR_ELEMENT Lnet/minecraft/client/render/VertexFormatElement;
+Accessible class net/minecraft/client/render/WorldRenderer$class_6600
+accessible field net/minecraft/client/render/Frustum field_34821 Lnet/minecraft/util/math/Vector4f;
+accessible field net/minecraft/client/render/Frustum x D
+accessible field net/minecraft/client/render/Frustum y D
+accessible field net/minecraft/client/render/Frustum z D


### PR DESCRIPTION
- Use a parallelStream to recalculate the frustum, so the cpu is better utilized
- Add a bit? of overdraw, but heavily reduce how often the frustum is recalculated

This slightly reduces the fps while standing still, but can up to double the fps while moving the camera/player.
In the future this should probably work more like Sodium does: with a flood fill and better optimized Frustums.