### PR TITLE
Fix Video Freeze on Resize (Fix #77)

### DIFF
--- a/src/main/java/net/vulkanmod/vulkan/Drawer.java
+++ b/src/main/java/net/vulkanmod/vulkan/Drawer.java
@@ -17,7 +17,6 @@ import java.nio.LongBuffer;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -88,11 +87,6 @@ public class Drawer {
         triangleStripIndexBuffer = new AutoIndexBuffer(1000, AutoIndexBuffer.DrawType.TRIANGLE_STRIP);
 
         this.allocateCommandBuffers();
-        // For some reason the unix nvidia driver have deadlocking issues.
-        // This completely freeze the game when resizing the game window.
-        // This issue doesn't seem to appear everywhere else.
-        nvidiaWorkaround = DeviceInfo.deviceName.toLowerCase(Locale.ROOT).contains("nvidia") &&
-                !System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
     }
 
     public void draw(ByteBuffer buffer, int drawMode, VertexFormat vertexFormat, int vertexCount)
@@ -136,17 +130,13 @@ public class Drawer {
 
     public void initiateRenderPass() {
 
-        if (nvidiaWorkaround) {
-            long time = System.currentTimeMillis();
-            // Linux Nvidia Driver can deadlock on vkWaitForFences, waiting 500ms
-            // in case vkWaitForFences doesn't deadlock seems a good compromise.
-            vkWaitForFences(device, inFlightFences.get(currentFrame), true, 500L);
-            if (System.currentTimeMillis() - time >= 500L) {
-                vkQueueWaitIdle(getGraphicsQueue());
-                vkQueueWaitIdle(getPresentQueue());
-            }
-        } else {
-            vkWaitForFences(device, inFlightFences.get(currentFrame), true, VUtil.UINT64_MAX);
+        long time = System.currentTimeMillis();
+        // Some drivers can deadlock on vkWaitForFences, waiting 500ms
+        // in case vkWaitForFences doesn't deadlock seems a good compromise.
+        vkWaitForFences(device, inFlightFences.get(currentFrame), true, 500L);
+        if (System.currentTimeMillis() - time >= 500L) {
+            vkQueueWaitIdle(getGraphicsQueue());
+            vkQueueWaitIdle(getPresentQueue());
         }
 
         CompletableFuture.runAsync(MemoryManager::freeBuffers);
@@ -360,16 +350,15 @@ public class Drawer {
     }
 
     private static void recreateSwapChain() {
-        // Linux Nvidia Driver can deadlock on vkWaitForFences,
+        // Some Drivers can deadlock on vkWaitForFences, so put 1000ms timeout.
         // also vkDeviceWaitIdle can deadlock if called after vkDestroy* calls.
-        // vkDeviceWaitIdle is called later when not using Linux Nvidia driver
-        if (nvidiaWorkaround) {
-            vkDeviceWaitIdle(device);
-        } else {
-            for(Long fence : inFlightFences) {
-                vkWaitForFences(device, fence, true, VUtil.UINT64_MAX);
-            }
+        long time = System.currentTimeMillis() + 1000L;
+        for(Long fence : inFlightFences) {
+            long wait = time - System.currentTimeMillis();
+            if (wait <= 0) break;
+            vkWaitForFences(device, fence, true, wait);
         }
+        vkDeviceWaitIdle(device);
 
         for(int i = 0; i < getSwapChainImages().size(); ++i) {
             vkDestroyFence(device, inFlightFences.get(i), null);

--- a/src/main/java/net/vulkanmod/vulkan/Vulkan.java
+++ b/src/main/java/net/vulkanmod/vulkan/Vulkan.java
@@ -54,8 +54,6 @@ public class Vulkan {
 
     private static final Set<String> VALIDATION_LAYERS;
 
-    static boolean nvidiaWorkaround; // Initialized in Drawer
-
     static {
         if(ENABLE_VALIDATION_LAYERS) {
             VALIDATION_LAYERS = new HashSet<>();
@@ -202,9 +200,6 @@ public class Vulkan {
         }
     }
 
-    /**
-     * Called from {@link Drawer#recreateSwapChain()}
-     */
     public static void recreateSwapChain() {
 
         try (MemoryStack stack = stackPush()) {
@@ -219,13 +214,6 @@ public class Vulkan {
         }
 
         Synchronization.waitFences();
-
-        // vkDeviceWaitIdle is called earlier when using Linux Nvidia driver
-        // Because calling vkDeviceWaitIdle here can cause deadlock.
-        // See Drawer.recreateSwapChain() for more info.
-        if (!nvidiaWorkaround) {
-            vkDeviceWaitIdle(device);
-        }
 
         swapChainFramebuffers.forEach(framebuffer -> vkDestroyFramebuffer(device, framebuffer, null));
 


### PR DESCRIPTION
I put comment on everything because it's really stupid.
The Linux Nvidia Driver is known to have issues with deadlocking.

This issue doesn't seem to appear everywhere else.
All workarounds in this PR are only enabled when needed.

Fix #77