### PR TITLE
Add additional Info to DebugHUD

### DIFF
--- a/src/main/java/net/vulkanmod/mixin/debug/DebugHudM.java
+++ b/src/main/java/net/vulkanmod/mixin/debug/DebugHudM.java
@@ -59,6 +59,7 @@ public abstract class DebugHudM {
         strings.add("CPU: " + DeviceInfo.cpuInfo);
         strings.add("GPU: " + DeviceInfo.deviceName);
         strings.add("Driver: " + DeviceInfo.driverVersion);
+        strings.add("Vulkan Version: " + DeviceInfo.vkVersion);
         strings.add("");
 
         return strings;

--- a/src/main/java/net/vulkanmod/mixin/debug/DebugHudM.java
+++ b/src/main/java/net/vulkanmod/mixin/debug/DebugHudM.java
@@ -58,9 +58,9 @@ public abstract class DebugHudM {
         strings.add("");
         strings.add("VulkanMod " + getVersion());
         strings.add("CPU: " + DeviceInfo.cpuInfo);
-        strings.add("GPU: " + DeviceInfo.deviceName);
-        strings.add("Driver: " + DeviceInfo.driverVersion);
-        strings.add("Vulkan Version: " + DeviceInfo.vkVersion);
+        strings.add("GPU: " + Vulkan.getDeviceInfo().deviceName);
+        strings.add("Driver: " + Vulkan.getDeviceInfo().driverVersion);
+        strings.add("Vulkan Version: " + Vulkan.getDeviceInfo().vkVersion);
 
         strings.add("");
 

--- a/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
+++ b/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
@@ -1,10 +1,15 @@
 package net.vulkanmod.vulkan;
 
+import org.jetbrains.annotations.NotNull;
 import oshi.SystemInfo;
 import oshi.hardware.CentralProcessor;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+
+import static org.lwjgl.vulkan.VK10.VK_VERSION_MAJOR;
+import static org.lwjgl.vulkan.VK10.VK_VERSION_MINOR;
+import static org.lwjgl.vulkan.VK10.VK_VERSION_PATCH;
 
 public class DeviceInfo {
 
@@ -12,6 +17,7 @@ public class DeviceInfo {
     public static final String vendorId;
     public static final String deviceName;
     public static final String driverVersion;
+    public static final String vkVersion;
 
     static {
         CentralProcessor centralProcessor = new SystemInfo().getHardware().getProcessor();
@@ -30,14 +36,35 @@ public class DeviceInfo {
 
 //        deviceName = new String(bytes, StandardCharsets.UTF_8);
             deviceName = StandardCharsets.UTF_8.decode(ByteBuffer.wrap(bytes)).toString();
-            driverVersion = String.valueOf(Vulkan.deviceProperties.driverVersion());
+            driverVersion = decodeDvrVersion(Vulkan.deviceProperties.driverVersion(), Vulkan.deviceProperties.vendorID());
+            vkVersion= decDefVersion(Vulkan.vkRawVersion);
         }
         else {
             vendorId = "n/a";
             deviceName = "n/a";
             driverVersion = "n/a";
+            vkVersion = "n/a";
         }
 
+    }
+
+    @NotNull
+    private static String decDefVersion(int v) {
+        return VK_VERSION_MAJOR(v) + "." + VK_VERSION_MINOR(v) + "." + VK_VERSION_PATCH(v);
+    }
+
+    //Source: https://old.reddit.com/r/vulkan/comments/fmift4/how_to_decode_driverversion_field_of/fl4mx0t/
+    //0x10DE = Nvidia: https://pcisig.com/membership/member-companies?combine=Nvidia
+    //https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceProperties.html
+
+    //todo: this should work with Nvidia + AMD but is not guaranteed to work with intel drivers in Windows and more obscure/Exotic Drivers/vendors
+    private static String decodeDvrVersion(int v, int i) {
+        return i == (0x10DE) ? decodeNvidia(v) : decDefVersion(v);
+    }
+
+    @NotNull
+    private static String decodeNvidia(int v) {
+        return (v >>> 22 & 0x3FF) + "." + (v >>> 14 & 0xff) + "." + (v >>> 6 & 0xff) + "." + (v & 0xf);
     }
 
 }

--- a/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
+++ b/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
@@ -81,9 +81,8 @@ public class DeviceInfo {
     }
 
     @NotNull
-    /**Major -> 000 - Minor -> 00 - Patch -> 00*/
     private static String decodeNvidia(int v) {
-        return (v >>> 22 & 0x3FF) + "." + (v >>> 14 & 0xff);
+        return (v >>> 22 & 0x3FF) + "." + (v >>> 14 & 0xff) + "." + (v >>> 6 & 0xff) + (v & 0xff);
     }
 
 }

--- a/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
+++ b/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
@@ -83,7 +83,7 @@ public class DeviceInfo {
     @NotNull
     /**Major -> 000 - Minor -> 00 - Patch -> 00*/
     private static String decodeNvidia(int v) {
-        return (v >>> 22 & 0x3FF) + "." + (v >>> 14 & 0xff) + "." + (v & 0xf >>> 1) + (v & 0xf);
+        return (v >>> 22 & 0x3FF) + "." + (v >>> 14 & 0xff);
     }
 
 }

--- a/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
+++ b/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
@@ -81,8 +81,9 @@ public class DeviceInfo {
     }
 
     @NotNull
+    /**Major -> 000 - Minor -> 00 - Patch -> 00*/
     private static String decodeNvidia(int v) {
-        return (v >>> 22 & 0x3FF) + "." + (v >>> 14 & 0xff) + "." + (v >>> 6 & 0xff) + "." + (v & 0xf);
+        return (v >>> 22 & 0x3FF) + "." + (v >>> 14 & 0xff) + "." + (v & 0xf >>> 1) + (v & 0xf);
     }
 
 }

--- a/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
+++ b/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
@@ -33,10 +33,10 @@ public class DeviceInfo {
 
     public static final String cpuInfo;
 
-    public static final String vendorId;
-    public static final String deviceName;
-    public static final String driverVersion;
-    public static final String vkVersion;
+    public final String vendorId;
+    public final String deviceName;
+    public final String driverVersion;
+    public final String vkVersion;
 
     public static final List<GraphicsCard> graphicsCards;
 
@@ -61,22 +61,11 @@ public class DeviceInfo {
         this.device = device;
         this.vendorId = String.valueOf(properties.vendorID());
         this.deviceName = properties.deviceNameString();
-        this.driverVersion = String.valueOf(properties.driverVersion());
+        this.driverVersion = decodeDvrVersion(properties.driverVersion(), properties.vendorID());
+        this.vkVersion = decDefVersion(Vulkan.vkRawVersion);
     }
 
     private String unsupportedExtensions(Set<String> requiredExtensions) {
-
-
-//        deviceName = new String(bytes, StandardCharsets.UTF_8);
-            deviceName = StandardCharsets.UTF_8.decode(ByteBuffer.wrap(bytes)).toString();
-            driverVersion = decodeDvrVersion(Vulkan.deviceProperties.driverVersion(), Vulkan.deviceProperties.vendorID());
-            vkVersion= decDefVersion(Vulkan.vkRawVersion);
-        }
-        else {
-            vendorId = "n/a";
-            deviceName = "n/a";
-            driverVersion = "n/a";
-            vkVersion = "n/a";
 
         try(MemoryStack stack = stackPush()) {
 
@@ -95,9 +84,11 @@ public class DeviceInfo {
             requiredExtensions.removeAll(extensions);
 
             return "Unsupported extensions: " + Arrays.toString(requiredExtensions.toArray());
-
         }
     }
+
+
+//
 
     public static String debugString(PointerBuffer ppPhysicalDevices, Set<String> requiredExtensions, VkInstance instance) {
         try (MemoryStack stack = stackPush()) {

--- a/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
+++ b/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
@@ -48,6 +48,7 @@ public class DeviceInfo {
 
     }
 
+    //Should Work with AMD: https://gpuopen.com/learn/decoding-radeon-vulkan-versions/
     @NotNull
     private static String decDefVersion(int v) {
         return VK_VERSION_MAJOR(v) + "." + VK_VERSION_MINOR(v) + "." + VK_VERSION_PATCH(v);
@@ -59,7 +60,24 @@ public class DeviceInfo {
 
     //todo: this should work with Nvidia + AMD but is not guaranteed to work with intel drivers in Windows and more obscure/Exotic Drivers/vendors
     private static String decodeDvrVersion(int v, int i) {
-        return i == (0x10DE) ? decodeNvidia(v) : decDefVersion(v);
+        return switch (i) {
+            case (0x10DE) -> decodeNvidia(v); //Nvidia
+            case (0x1022) -> decDefVersion(v); //AMD
+            case (0x5143) -> decQualCommVersion(v); //Qualcomm
+            case (0x8086) -> decIntelVersion(v); //Intel
+            default -> decDefVersion(v); //Either AMD or Unknown Driver version/vendor and.or Encoding Scheme
+        };
+    }
+
+    private static String decQualCommVersion(int v) {
+        return null;
+    }
+
+    //Source: https://www.intel.com/content/www/us/en/support/articles/000005654/graphics.html
+    //Won't Work with older Drivers (15.45 And.or older)
+    //Extremely unlikely to work as this uses Guess work+Assumptions
+    private static String decIntelVersion(int v) {
+        return (v >>> 30) + "." + (v >>> 27 & 0x7) + "." + (v & 0xF);
     }
 
     @NotNull

--- a/src/main/java/net/vulkanmod/vulkan/Vulkan.java
+++ b/src/main/java/net/vulkanmod/vulkan/Vulkan.java
@@ -5,6 +5,7 @@ import net.vulkanmod.vulkan.memory.MemoryTypes;
 import net.vulkanmod.vulkan.memory.StagingBuffer;
 import net.vulkanmod.vulkan.util.VUtil;
 import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.JNI;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.util.vma.*;
 import org.lwjgl.vulkan.*;
@@ -267,7 +268,7 @@ public class Vulkan {
 
             // Use calloc to initialize the structs with 0s. Otherwise, the program can crash due to random values
 
-            final VkApplicationInfo appInfo = VkApplicationInfo.callocStack(stack)
+            final VkApplicationInfo appInfo = VkApplicationInfo.mallocStack(stack)
                     .sType(VK_STRUCTURE_TYPE_APPLICATION_INFO)
                     .pApplicationName(stack.UTF8Safe("VulkanMod"))
                     .applicationVersion(vkRawVersion)
@@ -275,7 +276,7 @@ public class Vulkan {
                     .engineVersion(vkRawVersion)
                     .apiVersion(vkRawVersion); //try to use the actual version supported/used by the driver
 
-            final VkInstanceCreateInfo createInfo = VkInstanceCreateInfo.callocStack(stack)
+            final VkInstanceCreateInfo createInfo = VkInstanceCreateInfo.mallocStack(stack)
                     .sType(VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO)
                     .pApplicationInfo(appInfo)
             // enabledExtensionCount is implicitly set when you call ppEnabledExtensionNames

--- a/src/main/java/net/vulkanmod/vulkan/Vulkan.java
+++ b/src/main/java/net/vulkanmod/vulkan/Vulkan.java
@@ -23,6 +23,7 @@ import static org.lwjgl.glfw.GLFWVulkan.glfwGetRequiredInstanceExtensions;
 import static org.lwjgl.system.MemoryStack.stackGet;
 import static org.lwjgl.system.MemoryStack.stackPush;
 import static org.lwjgl.system.MemoryUtil.NULL;
+import static org.lwjgl.system.MemoryUtil.memGetInt;
 import static org.lwjgl.util.vma.Vma.vmaCreateAllocator;
 import static org.lwjgl.vulkan.EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
 import static org.lwjgl.vulkan.EXTDebugUtils.VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
@@ -52,21 +53,26 @@ public class Vulkan {
     private static final boolean ENABLE_VALIDATION_LAYERS = false;
 //    private static final boolean ENABLE_VALIDATION_LAYERS = true;
 
-    private static final Set<String> VALIDATION_LAYERS;
-    static {
-        if(ENABLE_VALIDATION_LAYERS) {
-            VALIDATION_LAYERS = new HashSet<>();
-            VALIDATION_LAYERS.add("VK_LAYER_KHRONOS_validation");
-
-        } else {
-            // We are not going to use it, so we don't create it
-            VALIDATION_LAYERS = null;
-        }
-    }
-
+    private static final Set<String> VALIDATION_LAYERS = (ENABLE_VALIDATION_LAYERS) ? new HashSet<>(Collections.singleton(("VK_LAYER_KHRONOS_validation"))) : null;
     private static final Set<String> DEVICE_EXTENSIONS = Stream.of(VK_KHR_SWAPCHAIN_EXTENSION_NAME)
             .collect(toSet());
 
+    private static final int vkRawVersion;
+
+    private static final boolean vk13;
+    private static final boolean vk12;
+    private static final boolean vk11;
+
+    static
+    {
+        long va = stackGet().nmalloc(4);
+        VK11.nvkEnumerateInstanceVersion(va);
+        vkRawVersion=memGetInt((va));
+        System.out.println(vkRawVersion);
+        vk13 = VK_VERSION_MINOR(vkRawVersion) >= 3; //Device.capabilities.Vulkan13/12/11/10() is only added in LWJGL 3.3.0 so its functionality is emulated here
+        vk12 = VK_VERSION_MINOR(vkRawVersion) >= 2;
+        vk11 = VK_VERSION_MINOR(vkRawVersion) >= 1;
+    }
 
 
     private static int debugCallback(int messageSeverity, int messageType, long pCallbackData, long pUserData) {
@@ -257,10 +263,10 @@ public class Vulkan {
 
             appInfo.sType(VK_STRUCTURE_TYPE_APPLICATION_INFO);
             appInfo.pApplicationName(stack.UTF8Safe("VulkanMod"));
-            appInfo.applicationVersion(VK_MAKE_VERSION(1, 0, 0));
+            appInfo.applicationVersion(vkRawVersion);
             appInfo.pEngineName(stack.UTF8Safe("No Engine"));
-            appInfo.engineVersion(VK_MAKE_VERSION(1, 0, 0));
-            appInfo.apiVersion(VK_API_VERSION_1_1);
+            appInfo.engineVersion(vkRawVersion);
+            appInfo.apiVersion(vkRawVersion); //try to use the actual version supported/used by the driver
 
             VkInstanceCreateInfo createInfo = VkInstanceCreateInfo.callocStack(stack);
 
@@ -286,6 +292,11 @@ public class Vulkan {
             }
 
             instance = new VkInstance(instancePtr.get(0), createInfo);
+
+            System.out.println("Vulkan 1.3 Supported?: "+ vk13);
+            System.out.println("Vulkan 1.2 Supported?: "+ vk12);
+            System.out.println("Vulkan 1.1 Supported?: "+ vk11);
+
         }
     }
 

--- a/src/main/java/net/vulkanmod/vulkan/Vulkan.java
+++ b/src/main/java/net/vulkanmod/vulkan/Vulkan.java
@@ -6,7 +6,6 @@ import net.vulkanmod.vulkan.memory.StagingBuffer;
 import net.vulkanmod.vulkan.util.VUtil;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryStack;
-import org.lwjgl.system.Pointer;
 import org.lwjgl.util.vma.*;
 import org.lwjgl.vulkan.*;
 
@@ -80,7 +79,7 @@ public class Vulkan {
 
         debugCreateInfo = ENABLE_VALIDATION_LAYERS ? populateDebugMessengerCreateInfo() : null;
         instance = createInstance();
-        if(ENABLE_VALIDATION_LAYERS) setupDebugMessenger(debugCreateInfo);
+        if(ENABLE_VALIDATION_LAYERS) setupDebugMessenger();
     }
 
 
@@ -305,7 +304,7 @@ public class Vulkan {
                 .pfnUserCallback(Vulkan::debugCallback);
     }
 
-    private static void setupDebugMessenger(VkDebugUtilsMessengerCreateInfoEXT createInfo) {
+    private static void setupDebugMessenger() {
 
         if(!ENABLE_VALIDATION_LAYERS) {
             return;
@@ -319,7 +318,7 @@ public class Vulkan {
 
             LongBuffer pDebugMessenger = stack.longs(VK_NULL_HANDLE);
 
-            if(createDebugUtilsMessengerEXT(instance, createInfo, null, pDebugMessenger) != VK_SUCCESS) {
+            if(createDebugUtilsMessengerEXT(instance, Vulkan.debugCreateInfo, null, pDebugMessenger) != VK_SUCCESS) {
                 throw new RuntimeException("Failed to set up debug messenger");
             }
 

--- a/src/main/java/net/vulkanmod/vulkan/Vulkan.java
+++ b/src/main/java/net/vulkanmod/vulkan/Vulkan.java
@@ -57,7 +57,7 @@ public class Vulkan {
     private static final Set<String> DEVICE_EXTENSIONS = Stream.of(VK_KHR_SWAPCHAIN_EXTENSION_NAME)
             .collect(toSet());
 
-    private static final int vkRawVersion;
+    static final int vkRawVersion;
 
     private static final boolean vk13;
     private static final boolean vk12;
@@ -72,6 +72,8 @@ public class Vulkan {
         vk13 = VK_VERSION_MINOR(vkRawVersion) >= 3; //Device.capabilities.Vulkan13/12/11/10() is only added in LWJGL 3.3.0 so its functionality is emulated here
         vk12 = VK_VERSION_MINOR(vkRawVersion) >= 2;
         vk11 = VK_VERSION_MINOR(vkRawVersion) >= 1;
+
+        System.out.println("Using Vulkan: "+VK_VERSION_MAJOR(vkRawVersion) + "." + VK_VERSION_MINOR(vkRawVersion) + "." + VK_VERSION_PATCH(vkRawVersion));
     }
 
 


### PR DESCRIPTION
This is a very small Pull Request that makes some minor changes the DebugHUD/GUI which adds the maximum supported Vulkan Version and the GPU Driver version to be displayed.

The Driver version is decoded via with specific bit shifts which coverts the raw Driver version into a human readable driver version number, and the Vulkan version is obtained with vkEnumerateInstanceVersion which can be used before the vkInstance is initialised.

The only issue I am currently aware of is the Driver Version decoder will likely not work with Intel Drivers on Windows and potentially highly Obscure/Exotic GPU Drivers/vendors that use different version formats (As the Driver Version this is only guaranteed to work and display correctly on Nvidia ATM)