### PR TITLE
hard fail on incompatible mods

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,7 +31,15 @@
     "minecraft": "1.18.x",
     "java": ">=17"
   },
-  "suggests": {
-    "another-mod": "*"
+
+  "breaks": {
+    "dashloader": "*",
+    "indium": "*",
+    "iris": "*",
+    "reeses-sodium-options": "*",
+    "skiptransitions": "*",
+    "sodium": "*",
+    "sodium-extra": "*",
+    "tiefix": "*"
   }
 }


### PR DESCRIPTION
this gives a better explanation to end users when a mod from #46 is loaded than just a crash
(also removed the default `suggest` dependency)