### PR TITLE
Fix messed up  screenshot Colours (Saving as BGR instead of RGB)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.14.8
 
 # Mod Properties
-	mod_version = 0.2.0+1
+	mod_version = 0.2.2
 	maven_group = net.vulkanmod
 	archives_base_name = VulkanMod_1.19.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.14.8
 
 # Mod Properties
-	mod_version = 0.2.2
+	mod_version = 0.2.0+1
 	maven_group = net.vulkanmod
 	archives_base_name = VulkanMod_1.19.2
 

--- a/src/main/java/net/vulkanmod/Initializer.java
+++ b/src/main/java/net/vulkanmod/Initializer.java
@@ -1,5 +1,6 @@
 package net.vulkanmod;
 
+import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
 import net.vulkanmod.config.Config;
@@ -9,14 +10,14 @@ import org.apache.logging.log4j.Logger;
 
 import java.nio.file.Path;
 
-public class Initializer implements ModInitializer {
+public class Initializer implements ClientModInitializer {
 	public static final Logger LOGGER = LogManager.getLogger("VulkanMod");
 
 	private static String VERSION;
 	public static Config CONFIG;
 
 	@Override
-	public void onInitialize() {
+	public void onInitializeClient() {
 
 		VERSION = FabricLoader.getInstance()
 				.getModContainer("vulkanmod")

--- a/src/main/java/net/vulkanmod/mixin/render/LevelRendererMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/render/LevelRendererMixin.java
@@ -25,7 +25,6 @@ import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(LevelRenderer.class)
 public abstract class LevelRendererMixin {
-    //TODO: remove class
 
     @Shadow @Final private Minecraft minecraft;
 

--- a/src/main/java/net/vulkanmod/mixin/screen/EnchantmentScreenM.java
+++ b/src/main/java/net/vulkanmod/mixin/screen/EnchantmentScreenM.java
@@ -69,8 +69,8 @@ public class EnchantmentScreenM extends AbstractContainerScreen<EnchantmentMenu>
         int l = (this.height - this.imageHeight) / 2;
         this.blit(poseStack, k, l, 0, 0, this.imageWidth, this.imageHeight);
         int m = (int)this.minecraft.getWindow().getGuiScale();
-//        RenderSystem.viewport((this.width - 320) / 2 * m, (this.height - 240) / 2 * m, 320 * m, 240 * m);
-        Drawer.setViewport((this.width - 320) / 2 * m, (this.height - 240) / 2 * m, 320 * m, 240 * m);
+        RenderSystem.viewport((this.width - 320) / 2 * m, (this.height - 240) / 2 * m, 320 * m, 240 * m);
+        Drawer.setViewport((this.width - 320) / 2 * k, (this.height - 240) / 2 * k, 320 * k, 240 * k);
 
         Matrix4f matrix4f = Matrix4f.createTranslateMatrix(-0.34f, 0.23f, 0.0f);
         matrix4f.multiply(Matrix4f.perspective(90.0, 1.3333334f, 9.0f, 80.0f));

--- a/src/main/java/net/vulkanmod/mixin/texture/MAbstractTexture.java
+++ b/src/main/java/net/vulkanmod/mixin/texture/MAbstractTexture.java
@@ -1,6 +1,5 @@
 package net.vulkanmod.mixin.texture;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.vulkanmod.gl.TextureMap;
 import net.vulkanmod.interfaces.VAbstractTextureI;
@@ -22,11 +21,7 @@ public abstract class MAbstractTexture implements VAbstractTextureI {
      */
     @Overwrite
     public void bind() {
-        if (!RenderSystem.isOnRenderThreadOrInit()) {
-            RenderSystem.recordRenderCall(this::bindTexture);
-        } else {
-            this.bindTexture();
-        }
+        this.bindTexture();
     }
 
     /**
@@ -43,15 +38,12 @@ public abstract class MAbstractTexture implements VAbstractTextureI {
      */
     @Overwrite
     public void releaseId() {
-        if(this.vulkanImage != null) {
-            this.vulkanImage.free();
-            this.vulkanImage = null;
+        //Lazy workaround to fix World Creation Menu (5122) related crashes
+        if(TextureMap.removeTexture(this.id) && this.id!=-1)
+        {
+            if(this.vulkanImage != null) this.vulkanImage.free();
         }
-//        else
-//            System.out.println("trying to free null image");
-
-        if(!TextureMap.removeTexture(this.id));
-//            throw new RuntimeException("texture id not found");
+        else System.out.println("texture id not found: "+this.id);
     }
 
     public void setId(int i) {

--- a/src/main/java/net/vulkanmod/mixin/texture/MDynamicTexture.java
+++ b/src/main/java/net/vulkanmod/mixin/texture/MDynamicTexture.java
@@ -2,7 +2,6 @@ package net.vulkanmod.mixin.texture;
 
 import com.mojang.blaze3d.pipeline.RenderCall;
 import com.mojang.blaze3d.platform.NativeImage;
-import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.renderer.texture.DynamicTexture;
 import net.vulkanmod.gl.TextureMap;
 import net.vulkanmod.interfaces.VAbstractTextureI;
@@ -13,11 +12,9 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(DynamicTexture.class)
-public abstract class MDynamicTexture {
+public class MDynamicTexture {
 
     @Shadow private NativeImage pixels;
-
-    @Shadow public abstract void upload();
 
     @Redirect(method = "<init>*", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/platform/TextureUtil;prepareImage(III)V"))
     private void redirect(int id, int width, int height) {
@@ -26,20 +23,10 @@ public abstract class MDynamicTexture {
 
     }
 
-//    @Redirect(method = "<init>(Lcom/mojang/blaze3d/platform/NativeImage;)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;recordRenderCall(Lcom/mojang/blaze3d/pipeline/RenderCall;)V"))
-//    private void redirect2(RenderCall renderCall) {
-//
-//        createTexture();
-//    }
-
     @Redirect(method = "<init>(Lcom/mojang/blaze3d/platform/NativeImage;)V", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;recordRenderCall(Lcom/mojang/blaze3d/pipeline/RenderCall;)V"))
     private void redirect2(RenderCall renderCall) {
 
-        RenderSystem.recordRenderCall(() -> {
-            createTexture();
-            this.upload();
-        });
-
+        createTexture();
     }
 
     private void createTexture() {

--- a/src/main/java/net/vulkanmod/mixin/texture/MTextureManager.java
+++ b/src/main/java/net/vulkanmod/mixin/texture/MTextureManager.java
@@ -44,7 +44,6 @@ public abstract class MTextureManager {
         AbstractTexture abstractTexture = this.getTexture(id, MissingTextureAtlasSprite.getTexture());
         if (abstractTexture != MissingTextureAtlasSprite.getTexture()) {
             //TODO: delete
-            abstractTexture.releaseId();
         }
     }
 }

--- a/src/main/java/net/vulkanmod/mixin/texture/VNativeImage.java
+++ b/src/main/java/net/vulkanmod/mixin/texture/VNativeImage.java
@@ -74,9 +74,9 @@ public abstract class VNativeImage {
      */
     @Overwrite
     public void downloadTexture(int level, boolean removeAlpha) {
-        RenderSystem.assertOnRenderThread();
-
-        VulkanImage.downloadTexture(this.width, this.height, this.pixels, Vulkan.getSwapChainImages().get(Drawer.getCurrentFrame()));
+//        RenderSystem.assertOnRenderThread();
+//
+//         VulkanImage.downloadTexture(this.width, this.height, this.pixels, Vulkan.getSwapChainImages().get(Drawer.getCurrentFrame()));
 
 
 

--- a/src/main/java/net/vulkanmod/mixin/texture/VNativeImage.java
+++ b/src/main/java/net/vulkanmod/mixin/texture/VNativeImage.java
@@ -76,15 +76,9 @@ public abstract class VNativeImage {
     public void downloadTexture(int level, boolean removeAlpha) {
         RenderSystem.assertOnRenderThread();
 
-        VulkanImage.downloadTexture(this.width, this.height, 4, this.buffer, Vulkan.getSwapChainImages().get(Drawer.getCurrentFrame()));
+        VulkanImage.downloadTexture(this.width, this.height, this.pixels, Vulkan.getSwapChainImages().get(Drawer.getCurrentFrame()));
 
-        if (removeAlpha && this.format.hasAlpha()) {
-            for (int i = 0; i < this.height; ++i) {
-                for (int j = 0; j < this.getWidth(); ++j) {
-                    this.setPixelRGBA(j, i, this.getPixelRGBA(j, i) | 255 << this.format.alphaOffset());
-                }
-            }
-        }
+
 
     }
 

--- a/src/main/java/net/vulkanmod/mixin/util/ScreenshotRecorderM.java
+++ b/src/main/java/net/vulkanmod/mixin/util/ScreenshotRecorderM.java
@@ -3,6 +3,11 @@ package net.vulkanmod.mixin.util;
 import com.mojang.blaze3d.pipeline.RenderTarget;
 import com.mojang.blaze3d.platform.NativeImage;
 import net.minecraft.client.Screenshot;
+import net.vulkanmod.render.chunk.TaskDispatcher;
+import net.vulkanmod.render.chunk.WorldRenderer;
+import net.vulkanmod.vulkan.Drawer;
+import net.vulkanmod.vulkan.Vulkan;
+import net.vulkanmod.vulkan.texture.VulkanImage;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 
@@ -14,12 +19,10 @@ public class ScreenshotRecorderM {
      */
     @Overwrite
     public static NativeImage takeScreenshot(RenderTarget framebuffer) {
-        int i = framebuffer.width;
-        int j = framebuffer.height;
 
-        NativeImage nativeimage = new NativeImage(i, j, false);
+        final NativeImage nativeimage = new NativeImage(framebuffer.width, framebuffer.height, false);
         //RenderSystem.bindTexture(p_92282_.getColorTextureId());
-        nativeimage.downloadTexture(0, true);
+        VulkanImage.downloadTexture(framebuffer.width, framebuffer.height, nativeimage.pixels, Vulkan.getSwapChainImages().get(Drawer.getCurrentFrame()));
         //nativeimage.flipY();
         return nativeimage;
     }

--- a/src/main/java/net/vulkanmod/mixin/util/ScreenshotRecorderM.java
+++ b/src/main/java/net/vulkanmod/mixin/util/ScreenshotRecorderM.java
@@ -2,17 +2,55 @@ package net.vulkanmod.mixin.util;
 
 import com.mojang.blaze3d.pipeline.RenderTarget;
 import com.mojang.blaze3d.platform.NativeImage;
+import net.minecraft.ChatFormatting;
+import net.minecraft.Util;
 import net.minecraft.client.Screenshot;
-import net.vulkanmod.render.chunk.TaskDispatcher;
-import net.vulkanmod.render.chunk.WorldRenderer;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
 import net.vulkanmod.vulkan.Drawer;
 import net.vulkanmod.vulkan.Vulkan;
 import net.vulkanmod.vulkan.texture.VulkanImage;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.io.File;
+import java.util.function.Consumer;
 
 @Mixin(Screenshot.class)
-public class ScreenshotRecorderM {
+public abstract class ScreenshotRecorderM {
+
+    @Shadow
+    private static File getFile(File file) {
+        return null;
+    }
+
+    @Shadow @Final private static Logger LOGGER;
+
+    @Overwrite
+    private static void _grab(File file, @Nullable String string, RenderTarget renderTarget, Consumer<Component> consumer) {
+
+
+        Util.ioPool().execute(() -> {
+            try (NativeImage nativeImage = takeScreenshot(renderTarget)) {
+                File file2 = new File(file, "screenshots");
+                file2.mkdir();
+
+                File file3 = string == null ? getFile(file2) : new File(file2, string);
+                nativeImage.writeToFile(file3);
+                Component component = Component.literal(file3.getName()).withStyle(ChatFormatting.UNDERLINE).withStyle((style) ->
+                        style.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_FILE, file3.getAbsolutePath())));
+                consumer.accept(Component.translatable("screenshot.success", component));
+            } catch (Exception var7) {
+                LOGGER.warn("Couldn't save screenshot", var7);
+                consumer.accept(Component.translatable("screenshot.failure", var7.getMessage()));
+            }
+
+        });
+    }
 
     /**
      * @author
@@ -22,7 +60,7 @@ public class ScreenshotRecorderM {
 
         final NativeImage nativeimage = new NativeImage(framebuffer.width, framebuffer.height, false);
         //RenderSystem.bindTexture(p_92282_.getColorTextureId());
-        VulkanImage.downloadTexture(framebuffer.width, framebuffer.height, nativeimage.pixels, Vulkan.getSwapChainImages().get(Drawer.getCurrentFrame()));
+        VulkanImage.downloadTextureAsync(framebuffer.width, framebuffer.height, nativeimage.pixels, Vulkan.getSwapChainImages().get(Drawer.getCurrentFrame()));
         //nativeimage.flipY();
         return nativeimage;
     }

--- a/src/main/java/net/vulkanmod/render/chunk/RenderSection.java
+++ b/src/main/java/net/vulkanmod/render/chunk/RenderSection.java
@@ -149,10 +149,6 @@ public class RenderSection {
 
     public boolean isDirty() { return this.dirty; }
 
-    public boolean isDirtyFromPlayer() {
-        return this.dirty && this.playerChanged;
-    }
-
     public BlockPos getOrigin() {
         return this.origin;
     }

--- a/src/main/java/net/vulkanmod/render/chunk/WorldRenderer.java
+++ b/src/main/java/net/vulkanmod/render/chunk/WorldRenderer.java
@@ -11,7 +11,6 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectListIterator;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.PrioritizeChunkUpdates;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.*;
 import net.vulkanmod.Initializer;
@@ -368,27 +367,27 @@ public class WorldRenderer {
             ChunkPos chunkpos = new ChunkPos(renderSection.getOrigin());
             if (renderSection.isDirty()
                     && this.level.getChunk(chunkpos.x, chunkpos.z).isClientLightReady()) {
-                boolean flag = false;
-                if (this.minecraft.options.prioritizeChunkUpdates().get() != PrioritizeChunkUpdates.NEARBY) {
-                    if (this.minecraft.options.prioritizeChunkUpdates().get() == PrioritizeChunkUpdates.PLAYER_AFFECTED) {
-                        flag = renderSection.isDirtyFromPlayer();
-                    }
-                } else {
-                    BlockPos blockpos1 = renderSection.getOrigin().offset(8, 8, 8);
-                    flag = blockpos1.distSqr(cameraPos) < 768.0D || renderSection.isDirtyFromPlayer();
-                }
-
-                if (flag) {
-                    this.minecraft.getProfiler().push("build_near_sync");
-                    renderSection.rebuildChunkSync(this.taskDispatcher, renderregioncache);
-                    renderSection.setNotDirty();
-                    this.minecraft.getProfiler().pop();
-                } else {
-                    list.add(renderSection);
-                }
+//                boolean flag = false;
+//                if (this.minecraft.options.prioritizeChunkUpdates != PrioritizeChunkUpdates.NEARBY) {
+//                    if (this.minecraft.options.prioritizeChunkUpdates == PrioritizeChunkUpdates.PLAYER_AFFECTED) {
+//                        flag = renderSection.isDirtyFromPlayer();
+//                    }
+//                } else {
+//                    BlockPos blockpos1 = renderSection.getOrigin().offset(8, 8, 8);
+//                    flag = blockpos1.distSqr(cameraPos) < 768.0D || renderSection.isDirtyFromPlayer();
+//                }
+//
+//                if (flag) {
+//                    this.minecraft.getProfiler().push("build_near_sync");
+//                    this.chunkRenderDispatcher.rebuildChunkSync(renderSection, renderregioncache);
+//                    renderSection.setNotDirty();
+//                    this.minecraft.getProfiler().pop();
+//                } else {
+//                    list.add(renderSection);
+//                }
                 list.add(renderSection);
             }
-
+            ;
         }
 
         this.minecraft.getProfiler().popPush("upload");
@@ -406,7 +405,6 @@ public class WorldRenderer {
 
         for(RenderSection renderSection : list) {
             renderSection.rebuildChunkAsync(this.taskDispatcher, renderregioncache);
-//            renderSection.rebuildChunkSync(this.taskDispatcher, renderregioncache);
             renderSection.setNotDirty();
         }
 

--- a/src/main/java/net/vulkanmod/vulkan/ComputePipeline.java
+++ b/src/main/java/net/vulkanmod/vulkan/ComputePipeline.java
@@ -21,28 +21,34 @@ import static org.lwjgl.vulkan.VK11.VK_PIPELINE_CREATE_DISPATCH_BASE;
 public class ComputePipeline  {
 
     private final VkDevice device = Vulkan.getDevice();
+//    private long ssboStorageBuffer;
+    private int size;
+    private long imgView;
     public long compPipeline;
     private final long compdescriptorSetLayout;
     private final long compdescriptorSetPool;
-    private int size;
+//    private VkExtent2D extent;
 
-    public long ssboStorageBuffer;
+    public long ssioStorageImage;
     public final long compDescriptorSet;
-    public long storageBufferMem;
+//    public long storageBufferMem;
+    public long storageImageMem;
     public final long compPipelineLayout;
     private long compShaderModule;
     private boolean closed;
     public final PointerBuffer data = MemoryUtil.memAllocPointer(1);
 
-    //Should extend Pipeline as this class is a mess and has a lot of copied functions,
-    //but ComputePipelines use differnt flags and Vulkan functions and are not interchangable with Graphics Piplelines
-    public ComputePipeline(String path, int size)
+    //Compute Pipelines are not interchangeable with Graphics Pipelines, hence why this is a seperate class
+    //Is Hardcoded for simplicity; used only for Image Copies ATM
+    public ComputePipeline(String path, VkExtent2D extent, int size)
     {
-        this.size=size;
+        this.size =size;
+//        this.extent =extent;
 //        super(path);
         compdescriptorSetLayout = createDescriptorSetLayout(path);
 
-        ssboStorageBuffer = getStorageBuffer(size);
+//        ssboStorageBuffer = getStorageBuffer(size);
+        ssioStorageImage = getStorageImage(extent);
 
 //        pushConstant.addField(Field.createField("float", "ScreenSize", 2, pushConstant));
 //        pushConstant.allocateBuffer();
@@ -50,48 +56,56 @@ public class ComputePipeline  {
         compPipeline = createComputePipeline(path);
         compdescriptorSetPool = createCompDescriptorPool();
         compDescriptorSet = allocateDescriptorSet();
+        imgView=Vulkan.createImageView(ssioStorageImage, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 1);
         try(MemoryStack stack = MemoryStack.stackPush())
         {
-            updateDescriptorSets(stack, size);
+            updateDescriptorSets(stack);
         }
         this.closed=false;
 
 
-        vmaMapMemory(Vulkan.getAllocator(), storageBufferMem, data);
+//        vmaMapMemory(Vulkan.getAllocator(), storageBufferMem, data);
 
     }
 
-    private long getStorageBuffer(int size) {
-        final long storageBuffer;
-        try(MemoryStack stack = stackPush())
-        {
-            PointerBuffer pBufferMemory=stack.mallocPointer(1);
-            LongBuffer pBuffer=stack.mallocLong(1);
+    private long getStorageImage(VkExtent2D extent2D) {
+        final long storageImage;
+        try(MemoryStack stack=MemoryStack.stackPush()){
+            LongBuffer pImage=stack.mallocLong(1);
+            PointerBuffer pImageMemory=stack.mallocPointer(1);
 
 
+            VkImageCreateInfo imageInfo = VkImageCreateInfo.callocStack(stack);
+            imageInfo.sType(VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO);
+            imageInfo.imageType(VK_IMAGE_TYPE_2D);
+            imageInfo.extent().width(extent2D.width());
+            imageInfo.extent().height(extent2D.height());
+            imageInfo.extent().depth(1);
+            imageInfo.mipLevels(1);
+            imageInfo.arrayLayers(1);
+            imageInfo.format(VK_FORMAT_B8G8R8A8_UNORM);
+            imageInfo.tiling(VK_IMAGE_TILING_OPTIMAL);
+            imageInfo.initialLayout(VK_IMAGE_LAYOUT_UNDEFINED);
+            imageInfo.usage(VK_IMAGE_USAGE_STORAGE_BIT|VK_IMAGE_USAGE_TRANSFER_SRC_BIT|VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+            imageInfo.samples(VK_SAMPLE_COUNT_1_BIT);
+            imageInfo.sharingMode(VK_SHARING_MODE_EXCLUSIVE);
+            imageInfo.pQueueFamilyIndices(stack.ints(2));
 
-                VkBufferCreateInfo bufferInfo = VkBufferCreateInfo.callocStack(stack);
-                bufferInfo.sType$Default();
-                bufferInfo.size(size);
-                bufferInfo.usage(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-                bufferInfo.sharingMode(VK_SHARING_MODE_EXCLUSIVE);
-    //
-                VmaAllocationCreateInfo allocationInfo  = VmaAllocationCreateInfo.callocStack(stack);
-//                allocationInfo.usage(VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE);
-                allocationInfo.flags(VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT|VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT|VMA_ALLOCATION_CREATE_HOST_ACCESS_ALLOW_TRANSFER_INSTEAD_BIT);
+            VmaAllocationCreateInfo allocationInfo  = VmaAllocationCreateInfo.callocStack(stack);
+            allocationInfo.usage(VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE);
+//                allocationInfo.flags(VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT|VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT|VMA_ALLOCATION_CREATE_HOST_ACCESS_ALLOW_TRANSFER_INSTEAD_BIT);
                 allocationInfo.memoryTypeBits(0);
-                allocationInfo.requiredFlags(VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT|VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+//                allocationInfo.requiredFlags(VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT|VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-                int result = vmaCreateBuffer(Vulkan.getAllocator(), bufferInfo, allocationInfo, pBuffer, pBufferMemory, null);
-                if(result != VK_SUCCESS) {
-                    throw new RuntimeException("Failed to create buffer:" + result);
-                }
+            var r = vmaCreateImage(Vulkan.getAllocator(), imageInfo, allocationInfo, pImage, pImageMemory, null);
+            if(r != VK_SUCCESS) {
+                throw new RuntimeException("Failed to create image: "+r);
+            }
 
-
-            storageBuffer = pBuffer.get(0);
-            storageBufferMem = pBufferMemory.get(0);
+            storageImage = pImage.get(0);
+            storageImageMem = pImageMemory.get(0);
         }
-        return storageBuffer;
+        return storageImage;
     }
 
 
@@ -101,8 +115,12 @@ public class ComputePipeline  {
 
 
                 VkDescriptorPoolSize.Buffer poolSizes = VkDescriptorPoolSize.callocStack(1, stack);
-                poolSizes.type(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-                poolSizes.descriptorCount(1);
+                poolSizes.get(0)
+                        .type(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
+                        .descriptorCount(1);
+//                poolSizes.get(1)
+//                        .type(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
+//                        .descriptorCount(1);
 
 
 
@@ -189,11 +207,18 @@ public class ComputePipeline  {
         try(MemoryStack stack = stackPush()) {
 
             VkDescriptorSetLayoutBinding.Buffer bindings = VkDescriptorSetLayoutBinding.callocStack(1, stack);
-            bindings.binding(0);
-            bindings.descriptorCount(1);
-            bindings.descriptorType(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-            bindings.pImmutableSamplers(null);
-            bindings.stageFlags(VK_SHADER_STAGE_COMPUTE_BIT);
+
+            bindings.get(0).binding(0)
+                    .descriptorCount(1)
+                    .descriptorType(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
+                    .pImmutableSamplers(null)
+                    .stageFlags(VK_SHADER_STAGE_COMPUTE_BIT);
+
+//            bindings.get(1).binding(1)
+//                    .descriptorCount(1)
+//                    .descriptorType(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
+//                    .pImmutableSamplers(null)
+//                    .stageFlags(VK_SHADER_STAGE_COMPUTE_BIT);
 
 
 
@@ -232,24 +257,39 @@ public class ComputePipeline  {
         }
     }
 
-    public void updateDescriptorSets(MemoryStack stack, int size)
+    public void updateDescriptorSets(MemoryStack stack)
     {
+//
+//        VkDescriptorBufferInfo.Buffer bufferInfos = VkDescriptorBufferInfo.callocStack(1, stack);
+//        bufferInfos.offset(0);
+//        bufferInfos.range(size);
+//        bufferInfos.buffer(ssboStorageBuffer);
 
-        VkDescriptorBufferInfo.Buffer bufferInfos = VkDescriptorBufferInfo.callocStack(1, stack);
-        bufferInfos.offset(0);
-        bufferInfos.range(size);
-        bufferInfos.buffer(ssboStorageBuffer);
+        VkDescriptorImageInfo.Buffer imageInfos = VkDescriptorImageInfo.callocStack(1, stack);
+        imageInfos.imageView(imgView);
+        imageInfos.imageLayout(VK_IMAGE_LAYOUT_GENERAL);
+        imageInfos.sampler(MemoryUtil.NULL);
 
 
 
         VkWriteDescriptorSet.Buffer ssboDescriptorWrite = VkWriteDescriptorSet.callocStack(1, stack);
-        ssboDescriptorWrite.sType$Default();
-        ssboDescriptorWrite.dstBinding(0);
-        ssboDescriptorWrite.dstArrayElement(0);
-        ssboDescriptorWrite.descriptorType(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-        ssboDescriptorWrite.descriptorCount(1);
-        ssboDescriptorWrite.pBufferInfo(bufferInfos);
-        ssboDescriptorWrite.dstSet(compDescriptorSet);
+        ssboDescriptorWrite.get(0)
+                .sType$Default()
+                .dstBinding(0)
+                .dstArrayElement(0)
+                .descriptorType(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
+                .descriptorCount(1)
+                .pImageInfo(imageInfos)
+                .dstSet(compDescriptorSet);
+//
+//        ssboDescriptorWrite.get(1)
+//                .sType$Default()
+//                .dstBinding(1)
+//                .dstArrayElement(0)
+//                .descriptorType(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
+//                .descriptorCount(1)
+//                .pBufferInfo(bufferInfos)
+//                .dstSet(compDescriptorSet);
 
 
 
@@ -258,17 +298,23 @@ public class ComputePipeline  {
 
     }
 
-    public void resizeBuffer(int size)
+    public void resizeBufferImage(int size, int width, int height)
     {
         if(this.closed || this.size==size) return; this.size=size;
 
         try(MemoryStack stack = MemoryStack.stackPush())
         {
-            vmaUnmapMemory(Vulkan.getAllocator(), storageBufferMem);
-            vmaDestroyBuffer(Vulkan.getAllocator(), ssboStorageBuffer, storageBufferMem);
-            ssboStorageBuffer =getStorageBuffer(size);
-            updateDescriptorSets(stack, size);
-            vmaMapMemory(Vulkan.getAllocator(), storageBufferMem, data);
+//            this.extent=VkExtent2D.malloc(stack).set(width, height);
+
+            vkDestroyImageView(device, imgView, null);
+            vmaDestroyImage(Vulkan.getAllocator(), ssioStorageImage, storageImageMem);
+//            vmaDestroyBuffer(Vulkan.getAllocator(), ssboStorageBuffer, storageBufferMem);
+
+//            ssboStorageBuffer = getStorageBuffer(this.size);
+            ssioStorageImage = getStorageImage(VkExtent2D.malloc(stack).set(width, height));
+            imgView=Vulkan.createImageView(ssioStorageImage, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 1);
+            updateDescriptorSets(stack);
+
         }
     }
 

--- a/src/main/java/net/vulkanmod/vulkan/ComputePipeline.java
+++ b/src/main/java/net/vulkanmod/vulkan/ComputePipeline.java
@@ -1,0 +1,296 @@
+package net.vulkanmod.vulkan;
+
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
+import org.lwjgl.util.vma.VmaAllocationCreateInfo;
+import org.lwjgl.vulkan.*;
+
+import java.nio.ByteBuffer;
+import java.nio.LongBuffer;
+
+import static net.vulkanmod.vulkan.Pipeline.createShaderModule;
+import static net.vulkanmod.vulkan.Pipeline.pipelineCache;
+import static net.vulkanmod.vulkan.ShaderSPIRVUtils.compileShaderFile;
+import static org.lwjgl.system.MemoryStack.stackPush;
+import static org.lwjgl.util.vma.Vma.*;
+import static org.lwjgl.vulkan.VK10.*;
+import static org.lwjgl.vulkan.VK10.vkDestroyShaderModule;
+import static org.lwjgl.vulkan.VK11.VK_PIPELINE_CREATE_DISPATCH_BASE;
+
+public class ComputePipeline  {
+
+    private final VkDevice device = Vulkan.getDevice();
+    public long compPipeline;
+    private final long compdescriptorSetLayout;
+    private final long compdescriptorSetPool;
+    private int size;
+
+    public long ssboStorageBuffer;
+    public final long compDescriptorSet;
+    public long storageBufferMem;
+    public final long compPipelineLayout;
+    private long compShaderModule;
+    private boolean closed;
+    public final PointerBuffer data = MemoryUtil.memAllocPointer(1);
+
+    //Should extend Pipeline as this class is a mess and has a lot of copied functions,
+    //but ComputePipelines use differnt flags and Vulkan functions and are not interchangable with Graphics Piplelines
+    public ComputePipeline(String path, int size)
+    {
+        this.size=size;
+//        super(path);
+        compdescriptorSetLayout = createDescriptorSetLayout(path);
+
+        ssboStorageBuffer = getStorageBuffer(size);
+
+//        pushConstant.addField(Field.createField("float", "ScreenSize", 2, pushConstant));
+//        pushConstant.allocateBuffer();
+        compPipelineLayout = createPipelineLayout();
+        compPipeline = createComputePipeline(path);
+        compdescriptorSetPool = createCompDescriptorPool();
+        compDescriptorSet = allocateDescriptorSet();
+        try(MemoryStack stack = MemoryStack.stackPush())
+        {
+            updateDescriptorSets(stack, size);
+        }
+        this.closed=false;
+
+
+        vmaMapMemory(Vulkan.getAllocator(), storageBufferMem, data);
+
+    }
+
+    private long getStorageBuffer(int size) {
+        final long storageBuffer;
+        try(MemoryStack stack = stackPush())
+        {
+            PointerBuffer pBufferMemory=stack.mallocPointer(1);
+            LongBuffer pBuffer=stack.mallocLong(1);
+
+
+
+                VkBufferCreateInfo bufferInfo = VkBufferCreateInfo.callocStack(stack);
+                bufferInfo.sType$Default();
+                bufferInfo.size(size);
+                bufferInfo.usage(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+                bufferInfo.sharingMode(VK_SHARING_MODE_EXCLUSIVE);
+    //
+                VmaAllocationCreateInfo allocationInfo  = VmaAllocationCreateInfo.callocStack(stack);
+//                allocationInfo.usage(VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE);
+                allocationInfo.flags(VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT|VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT|VMA_ALLOCATION_CREATE_HOST_ACCESS_ALLOW_TRANSFER_INSTEAD_BIT);
+                allocationInfo.memoryTypeBits(0);
+                allocationInfo.requiredFlags(VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT|VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+
+                int result = vmaCreateBuffer(Vulkan.getAllocator(), bufferInfo, allocationInfo, pBuffer, pBufferMemory, null);
+                if(result != VK_SUCCESS) {
+                    throw new RuntimeException("Failed to create buffer:" + result);
+                }
+
+
+            storageBuffer = pBuffer.get(0);
+            storageBufferMem = pBufferMemory.get(0);
+        }
+        return storageBuffer;
+    }
+
+
+    private long createCompDescriptorPool() {
+
+            try(MemoryStack stack = stackPush()) {
+
+
+                VkDescriptorPoolSize.Buffer poolSizes = VkDescriptorPoolSize.callocStack(1, stack);
+                poolSizes.type(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+                poolSizes.descriptorCount(1);
+
+
+
+                VkDescriptorPoolCreateInfo poolInfo = VkDescriptorPoolCreateInfo.callocStack(stack);
+                poolInfo.sType$Default();
+                poolInfo.pPoolSizes(poolSizes);
+                poolInfo.maxSets(1);
+                //poolInfo.flags(VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT);
+
+                LongBuffer pDescriptorPool = stack.mallocLong(1);
+
+
+                    if(vkCreateDescriptorPool(device, poolInfo, null, pDescriptorPool) != VK_SUCCESS) {
+                        throw new RuntimeException("Failed to create descriptor pool");
+                    }
+                    return pDescriptorPool.get(0);
+
+            }
+
+    }
+
+    private long createComputePipeline(String path) {
+
+//                SPIRV vertShaderSPIRV = compileShader(path + ".vsh", "vertex");
+//                SPIRV fragShaderSPIRV = compileShader(path + ".fsh", "fragment");
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            ShaderSPIRVUtils.SPIRV compShaderSPIRV = compileShaderFile(path + ".csh", ShaderSPIRVUtils.ShaderKind.COMPUTE_SHADER);
+
+            compShaderModule = createShaderModule(compShaderSPIRV.bytecode());
+
+            ByteBuffer entryPoint = stack.UTF8("main");
+
+
+
+            VkPipelineShaderStageCreateInfo compShaderStageInfo = VkPipelineShaderStageCreateInfo.callocStack(stack);
+            compShaderStageInfo.sType$Default();
+            compShaderStageInfo.stage(VK_SHADER_STAGE_COMPUTE_BIT);
+            compShaderStageInfo.module(compShaderModule);
+            compShaderStageInfo.pName(entryPoint);
+
+
+
+            VkComputePipelineCreateInfo.Buffer pipelineInfo = VkComputePipelineCreateInfo.callocStack(1, stack);
+            pipelineInfo.sType$Default();
+            pipelineInfo.flags(VK_PIPELINE_CREATE_DISPATCH_BASE);
+            pipelineInfo.stage(compShaderStageInfo);
+            pipelineInfo.layout(compPipelineLayout);
+            pipelineInfo.basePipelineHandle(VK_NULL_HANDLE);
+            pipelineInfo.basePipelineIndex(-1);
+
+            LongBuffer pGraphicsPipeline = stack.mallocLong(1);
+
+            if(vkCreateComputePipelines(device, pipelineCache, pipelineInfo, null, pGraphicsPipeline) != VK_SUCCESS) {
+                throw new RuntimeException("Failed to create graphics pipeline");
+            }
+
+            return pGraphicsPipeline.get(0);
+
+        }
+    }
+
+    private long createPipelineLayout() {
+        try(MemoryStack stack = stackPush()) {
+            // ===> PIPELINE LAYOUT CREATION <===
+
+            VkPipelineLayoutCreateInfo pipelineLayoutInfo = VkPipelineLayoutCreateInfo.callocStack(stack);
+            pipelineLayoutInfo.sType$Default();
+            pipelineLayoutInfo.pSetLayouts(stack.longs(compdescriptorSetLayout));
+
+            LongBuffer pPipelineLayout = stack.longs(VK_NULL_HANDLE);
+
+            if(vkCreatePipelineLayout(device, pipelineLayoutInfo, null, pPipelineLayout) != VK_SUCCESS) {
+                throw new RuntimeException("Failed to create pipeline layout");
+            }
+
+            return pPipelineLayout.get(0);
+        }
+    }
+
+    private long createDescriptorSetLayout(String path) {
+
+
+
+        try(MemoryStack stack = stackPush()) {
+
+            VkDescriptorSetLayoutBinding.Buffer bindings = VkDescriptorSetLayoutBinding.callocStack(1, stack);
+            bindings.binding(0);
+            bindings.descriptorCount(1);
+            bindings.descriptorType(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+            bindings.pImmutableSamplers(null);
+            bindings.stageFlags(VK_SHADER_STAGE_COMPUTE_BIT);
+
+
+
+            VkDescriptorSetLayoutCreateInfo layoutInfo = VkDescriptorSetLayoutCreateInfo.callocStack(stack);
+            layoutInfo.sType$Default();
+            layoutInfo.pBindings(bindings);
+
+            LongBuffer pDescriptorSetLayout = stack.mallocLong(1);
+
+            if(vkCreateDescriptorSetLayout(device, layoutInfo, null, pDescriptorSetLayout) != VK_SUCCESS) {
+                throw new RuntimeException("Failed to create descriptor set layout");
+            }
+            return pDescriptorSetLayout.get(0);
+        }
+    }
+
+    private long allocateDescriptorSet() {
+        try(MemoryStack stack = stackPush()) {
+
+            VkDescriptorSetAllocateInfo allocInfo = VkDescriptorSetAllocateInfo.callocStack(stack);
+            allocInfo.sType$Default();
+            allocInfo.descriptorPool(compdescriptorSetPool);
+            allocInfo.pSetLayouts(stack.longs(compdescriptorSetLayout));
+
+
+
+            LongBuffer pDescriptorSet = stack.mallocLong(1);
+
+            int result = vkAllocateDescriptorSets(device, allocInfo, pDescriptorSet);
+
+            if (result != VK_SUCCESS) {
+                throw new RuntimeException("Failed to allocate descriptor sets. Result:" + result);
+            }
+
+            return pDescriptorSet.get(0);
+        }
+    }
+
+    public void updateDescriptorSets(MemoryStack stack, int size)
+    {
+
+        VkDescriptorBufferInfo.Buffer bufferInfos = VkDescriptorBufferInfo.callocStack(1, stack);
+        bufferInfos.offset(0);
+        bufferInfos.range(size);
+        bufferInfos.buffer(ssboStorageBuffer);
+
+
+
+        VkWriteDescriptorSet.Buffer ssboDescriptorWrite = VkWriteDescriptorSet.callocStack(1, stack);
+        ssboDescriptorWrite.sType$Default();
+        ssboDescriptorWrite.dstBinding(0);
+        ssboDescriptorWrite.dstArrayElement(0);
+        ssboDescriptorWrite.descriptorType(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+        ssboDescriptorWrite.descriptorCount(1);
+        ssboDescriptorWrite.pBufferInfo(bufferInfos);
+        ssboDescriptorWrite.dstSet(compDescriptorSet);
+
+
+
+        vkUpdateDescriptorSets(device, ssboDescriptorWrite, null);
+
+
+    }
+
+    public void resizeBuffer(int size)
+    {
+        if(this.closed || this.size==size) return; this.size=size;
+
+        try(MemoryStack stack = MemoryStack.stackPush())
+        {
+            vmaUnmapMemory(Vulkan.getAllocator(), storageBufferMem);
+            vmaDestroyBuffer(Vulkan.getAllocator(), ssboStorageBuffer, storageBufferMem);
+            ssboStorageBuffer =getStorageBuffer(size);
+            updateDescriptorSets(stack, size);
+            vmaMapMemory(Vulkan.getAllocator(), storageBufferMem, data);
+        }
+    }
+
+
+    public void close()
+    {
+        this.closed=true;
+
+        data.free();
+//        vmaDestroyBuffer(Vulkan.getAllocator(), storageBuffer, storageBufferMem);
+        vkDestroyShaderModule(device, compShaderModule, null);
+        vkDestroyDescriptorSetLayout(device, compdescriptorSetLayout, null);
+        vkDestroyDescriptorPool(device, compdescriptorSetPool, null);
+        vkDestroyPipeline(device, compPipeline, null);
+//        vkDestroyPipelineLayout(Vulkan.getDevice(), compPipelineLayout, null);
+
+    }
+
+
+    public void reload() {
+        vkDestroyShaderModule(device, compShaderModule, null);
+        vkDestroyPipeline(device, compPipeline, null);
+        compPipeline = createComputePipeline("extra/swizzle");
+    }
+}

--- a/src/main/java/net/vulkanmod/vulkan/Drawer.java
+++ b/src/main/java/net/vulkanmod/vulkan/Drawer.java
@@ -134,13 +134,15 @@ public class Drawer {
 
         try (MemoryStack stack = stackPush()) {
 
-            IntBuffer width = stack.ints(0);
-            IntBuffer height = stack.ints(0);
+            IntBuffer pWidth = stack.mallocInt(1);
+            IntBuffer pHeight = stack.mallocInt(1);
 
-            glfwGetFramebufferSize(window, width, height);
-            skipRendering = Minecraft.getInstance().noRender = width.get(0) == 0 && height.get(0) == 0;
+            glfwGetFramebufferSize(window, pWidth, pHeight);
+            final int width = pWidth.get(0);
+            final int height = pHeight.get(0);
+            skipRendering = Minecraft.getInstance().noRender = width == 0 && height == 0;
 
-            if(!skipRendering) VulkanImage.computePipeline.resizeBuffer(width.get(0) * height.get(0) * 4);
+            if(!skipRendering) VulkanImage.computePipeline.resizeBufferImage(width * height * 4, width, height);
         }
 
         if(skipRendering) return;

--- a/src/main/java/net/vulkanmod/vulkan/Drawer.java
+++ b/src/main/java/net/vulkanmod/vulkan/Drawer.java
@@ -142,7 +142,7 @@ public class Drawer {
             final int height = pHeight.get(0);
             skipRendering = Minecraft.getInstance().noRender = width == 0 && height == 0;
 
-            if(!skipRendering) VulkanImage.computePipeline.resizeBufferImage(width * height * 4, width, height);
+//            if(!skipRendering) VulkanImage.computePipeline.resizeBufferImage(width * height * 4, width, height);
         }
 
         if(skipRendering) return;

--- a/src/main/java/net/vulkanmod/vulkan/Drawer.java
+++ b/src/main/java/net/vulkanmod/vulkan/Drawer.java
@@ -8,6 +8,7 @@ import net.vulkanmod.interfaces.ShaderMixed;
 import net.vulkanmod.vulkan.memory.*;
 import net.vulkanmod.vulkan.memory.MemoryTypes;
 import net.vulkanmod.vulkan.shader.PushConstant;
+import net.vulkanmod.vulkan.texture.VulkanImage;
 import net.vulkanmod.vulkan.util.VUtil;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryStack;
@@ -17,7 +18,7 @@ import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.nio.LongBuffer;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
+
 
 import static net.vulkanmod.vulkan.Vulkan.*;
 import static org.lwjgl.glfw.GLFW.glfwGetFramebufferSize;
@@ -137,13 +138,9 @@ public class Drawer {
             IntBuffer height = stack.ints(0);
 
             glfwGetFramebufferSize(window, width, height);
-            if (width.get(0) == 0 && height.get(0) == 0) {
-                skipRendering = true;
-                Minecraft.getInstance().noRender = true;
-            } else {
-                skipRendering = false;
-                Minecraft.getInstance().noRender = false;
-            }
+            skipRendering = Minecraft.getInstance().noRender = width.get(0) == 0 && height.get(0) == 0;
+
+            if(!skipRendering) VulkanImage.computePipeline.resizeBuffer(width.get(0) * height.get(0) * 4);
         }
 
         if(skipRendering) return;

--- a/src/main/java/net/vulkanmod/vulkan/Pipeline.java
+++ b/src/main/java/net/vulkanmod/vulkan/Pipeline.java
@@ -42,7 +42,7 @@ public class Pipeline {
     public static final BlendState NO_BLEND_STATE = new BlendState(false, 0, 0, 0, 0);
 
     private static final VkDevice device = Vulkan.getDevice();
-    private static final long pipelineCache = createPipelineCache();
+    static final long pipelineCache = createPipelineCache();
     private static final int imagesSize = getSwapChainImages().size();
 
     private String path;
@@ -540,7 +540,7 @@ public class Pipeline {
         };
     }
 
-    private static long createShaderModule(ByteBuffer spirvCode) {
+    static long createShaderModule(ByteBuffer spirvCode) {
 
         try(MemoryStack stack = stackPush()) {
 
@@ -600,6 +600,18 @@ public class Pipeline {
 
     public long getLayout() { return pipelineLayout; }
 
+    public void reload() {
+        vkDestroyShaderModule(device, vertShaderModule, null);
+        vkDestroyShaderModule(device, fragShaderModule, null);
+        for (Map.Entry<PipelineState, Long> entry : graphicsPipelines.entrySet()) {
+            PipelineState state = entry.getKey();
+            long pipeline = entry.getValue();
+            vkDestroyPipeline(device, pipeline, null);
+        }
+        graphicsPipelines.clear();
+        graphicsPipelines.computeIfAbsent(new PipelineState(DEFAULT_BLEND_STATE, DEFAULT_DEPTH_STATE, DEFAULT_LOGICOP_STATE, DEFAULT_COLORMASK),
+                (pipelineState) -> createGraphicsPipeline(vertexFormat, pipelineState));
+    }
     private class DescriptorSetsUnit {
         private long descriptorSet;
 

--- a/src/main/java/net/vulkanmod/vulkan/ShaderSPIRVUtils.java
+++ b/src/main/java/net/vulkanmod/vulkan/ShaderSPIRVUtils.java
@@ -16,6 +16,27 @@ import static org.lwjgl.util.shaderc.Shaderc.*;
 
 public class ShaderSPIRVUtils {
     private static long compiler;
+    private static final int vkEnv;
+    private static final int spvVer;
+
+    static
+    {
+        var vkCapabilitiesDevice = Vulkan.getDevice().getCapabilities();
+        if(vkCapabilitiesDevice.Vulkan13 & vkCapabilitiesDevice.Vulkan12 & vkCapabilitiesDevice.Vulkan11)
+        {
+            vkEnv =shaderc_env_version_vulkan_1_3;
+            spvVer=shaderc_spirv_version_1_6;
+        }
+        else if(!vkCapabilitiesDevice.Vulkan13 & vkCapabilitiesDevice.Vulkan12 &  vkCapabilitiesDevice.Vulkan11)
+        {
+            vkEnv =shaderc_env_version_vulkan_1_2;
+            spvVer=shaderc_spirv_version_1_5;
+        }else
+        {
+            vkEnv =shaderc_env_version_vulkan_1_1;
+            spvVer=shaderc_spirv_version_1_3;
+        }
+    }
 
     public static SPIRV compileShaderFile(String shaderFile, ShaderKind shaderKind) {
         String path = ShaderSPIRVUtils.class.getResource("/assets/vulkanmod/shaders/" + shaderFile).toExternalForm();
@@ -46,7 +67,10 @@ public class ShaderSPIRVUtils {
             throw new RuntimeException("Failed to create compiler options");
         }
 
-//        shaderc_compile_options_set_optimization_level(options, shaderc_optimization_level_performance);
+
+        shaderc_compile_options_set_target_env(options, shaderc_target_env_vulkan, vkEnv);
+        shaderc_compile_options_set_target_spirv(options, shaderKind == ShaderKind.COMPUTE_SHADER && vkEnv == shaderc_env_version_vulkan_1_3 ? shaderc_spirv_version_1_5 : spvVer);
+        shaderc_compile_options_set_optimization_level(options, shaderc_optimization_level_performance);
 
         long result = shaderc_compile_into_spv(compiler, source, shaderKind.kind, filename, "main", options);
 
@@ -81,6 +105,7 @@ public class ShaderSPIRVUtils {
     public enum ShaderKind {
 
         VERTEX_SHADER(shaderc_glsl_vertex_shader),
+        COMPUTE_SHADER(shaderc_glsl_compute_shader),
         GEOMETRY_SHADER(shaderc_glsl_geometry_shader),
         FRAGMENT_SHADER(shaderc_glsl_fragment_shader);
 

--- a/src/main/java/net/vulkanmod/vulkan/Synchronization.java
+++ b/src/main/java/net/vulkanmod/vulkan/Synchronization.java
@@ -10,8 +10,9 @@ import java.nio.LongBuffer;
 import static org.lwjgl.vulkan.VK10.*;
 
 public class Synchronization {
-    private static final int allocSize = 20000;
+    private static final int allocSize = 10000;
     private static final LongBuffer fences = MemoryUtil.memAllocLong(allocSize);
+    private static final PointerBuffer freeableCmdBuffers = MemoryUtil.memAllocPointer(allocSize);
     private static int idx = 0;
 
     public synchronized static void addFence(long fence) {

--- a/src/main/java/net/vulkanmod/vulkan/Vulkan.java
+++ b/src/main/java/net/vulkanmod/vulkan/Vulkan.java
@@ -552,7 +552,7 @@ public class Vulkan {
             createInfo.imageColorSpace(surfaceFormat.colorSpace());
             createInfo.imageExtent(extent);
             createInfo.imageArrayLayers(1);
-            createInfo.imageUsage(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+            createInfo.imageUsage(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT|VK_IMAGE_USAGE_STORAGE_BIT);
 
             QueueFamilyIndices indices = findQueueFamilies(physicalDevice);
 
@@ -1176,6 +1176,8 @@ public class Vulkan {
     }
 
     public static List<Long> getSwapChainImages() { return swapChainImages; }
+
+    public static List<Long> getSwapChainImageViews() { return swapChainImageViews; }
 
     public static long getRenderPass()
     {

--- a/src/main/java/net/vulkanmod/vulkan/Vulkan.java
+++ b/src/main/java/net/vulkanmod/vulkan/Vulkan.java
@@ -4,6 +4,7 @@ import net.vulkanmod.Initializer;
 import net.vulkanmod.vulkan.memory.MemoryManager;
 import net.vulkanmod.vulkan.memory.MemoryTypes;
 import net.vulkanmod.vulkan.memory.StagingBuffer;
+import net.vulkanmod.vulkan.texture.VulkanImage;
 import net.vulkanmod.vulkan.util.VUtil;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.PointerBuffer;
@@ -45,6 +46,7 @@ import static org.lwjgl.vulkan.KHRSwapchain.vkDestroySwapchainKHR;
 import static org.lwjgl.vulkan.KHRSwapchain.vkGetSwapchainImagesKHR;
 import static org.lwjgl.vulkan.VK10.*;
 import static org.lwjgl.vulkan.VK11.VK_API_VERSION_1_1;
+import static org.lwjgl.vulkan.VK11.vkEnumerateInstanceVersion;
 
 public class Vulkan {
 
@@ -56,7 +58,16 @@ public class Vulkan {
 //    private static final boolean ENABLE_VALIDATION_LAYERS = true;
 
     public static final Set<String> VALIDATION_LAYERS;
+    public static boolean isRGB;
+
+    static final int vkVersion;
+
     static {
+
+        try(MemoryStack stack = MemoryStack.stackPush())
+        {
+            vkVersion = getVkVersion(stack);
+        }
         if(ENABLE_VALIDATION_LAYERS) {
             VALIDATION_LAYERS = new HashSet<>();
             VALIDATION_LAYERS.add("VK_LAYER_KHRONOS_validation");
@@ -239,6 +250,9 @@ public class Vulkan {
 
     public static void cleanUp() {
         vkDeviceWaitIdle(device);
+
+        VulkanImage.computePipeline.close();
+
         vkDestroyCommandPool(device, commandPool, null);
         vkDestroyCommandPool(device, TransferQueue.getCommandPool(), null);
 
@@ -262,10 +276,10 @@ public class Vulkan {
 
             appInfo.sType(VK_STRUCTURE_TYPE_APPLICATION_INFO);
             appInfo.pApplicationName(stack.UTF8Safe("VulkanMod"));
-            appInfo.applicationVersion(VK_MAKE_VERSION(1, 0, 0));
+            appInfo.applicationVersion(vkVersion);
             appInfo.pEngineName(stack.UTF8Safe("No Engine"));
-            appInfo.engineVersion(VK_MAKE_VERSION(1, 0, 0));
-            appInfo.apiVersion(VK_API_VERSION_1_1);
+            appInfo.engineVersion(vkVersion);
+            appInfo.apiVersion(vkVersion);
 
             VkInstanceCreateInfo createInfo = VkInstanceCreateInfo.callocStack(stack);
 
@@ -441,7 +455,7 @@ public class Vulkan {
                 throw new RuntimeException("Failed to create logical device");
             }
 
-            device = new VkDevice(pDevice.get(0), physicalDevice, createInfo);
+            device = new VkDevice(pDevice.get(0), physicalDevice, createInfo, vkVersion);
 
             PointerBuffer pQueue = stack.pointers(VK_NULL_HANDLE);
 
@@ -465,6 +479,7 @@ public class Vulkan {
             allocatorCreateInfo.device(device);
             allocatorCreateInfo.pVulkanFunctions(vulkanFunctions);
             allocatorCreateInfo.instance(instance);
+            allocatorCreateInfo.vulkanApiVersion(vkVersion);
 
             PointerBuffer pAllocator = stack.pointers(VK_NULL_HANDLE);
 
@@ -474,6 +489,12 @@ public class Vulkan {
 
             allocator = pAllocator.get(0);
         }
+    }
+
+    private static int getVkVersion(MemoryStack stack) {
+        var a = stack.npointer(0);
+        VK11.nvkEnumerateInstanceVersion(a);
+        return MemoryUtil.memGetInt(a);
     }
 
     private static void createCommandPool() {
@@ -594,14 +615,17 @@ public class Vulkan {
             VkAttachmentDescription.Buffer attachments = VkAttachmentDescription.callocStack(2, stack);
             VkAttachmentReference.Buffer attachmentRefs = VkAttachmentReference.callocStack(2, stack);
 
+            VKCapabilitiesDevice capabilities = device.getCapabilities();
+            final boolean storeNone = capabilities.VK_EXT_load_store_op_none;
+
             // Color attachments
             VkAttachmentDescription colorAttachment = attachments.get(0);
             colorAttachment.format(swapChainImageFormat);
             colorAttachment.samples(VK_SAMPLE_COUNT_1_BIT);
-            colorAttachment.loadOp(VK_ATTACHMENT_LOAD_OP_CLEAR);
-            colorAttachment.storeOp(VK_ATTACHMENT_STORE_OP_STORE);
-            colorAttachment.stencilLoadOp(VK_ATTACHMENT_LOAD_OP_DONT_CARE);
-            colorAttachment.stencilStoreOp(VK_ATTACHMENT_STORE_OP_DONT_CARE);
+            colorAttachment.loadOp(storeNone ? EXTLoadStoreOpNone.VK_ATTACHMENT_LOAD_OP_NONE_EXT : VK_ATTACHMENT_LOAD_OP_CLEAR);
+            colorAttachment.storeOp(storeNone ? VK13.VK_ATTACHMENT_STORE_OP_NONE : VK_ATTACHMENT_STORE_OP_STORE);
+            colorAttachment.stencilLoadOp(storeNone ? EXTLoadStoreOpNone.VK_ATTACHMENT_LOAD_OP_NONE_EXT : VK_ATTACHMENT_LOAD_OP_DONT_CARE);
+            colorAttachment.stencilStoreOp(storeNone ? VK13.VK_ATTACHMENT_STORE_OP_NONE : VK_ATTACHMENT_STORE_OP_DONT_CARE);
             colorAttachment.initialLayout(VK_IMAGE_LAYOUT_UNDEFINED);
             colorAttachment.finalLayout(VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
 
@@ -616,10 +640,10 @@ public class Vulkan {
             VkAttachmentDescription depthAttachment = attachments.get(1);
             depthAttachment.format(findDepthFormat());
             depthAttachment.samples(VK_SAMPLE_COUNT_1_BIT);
-            depthAttachment.loadOp(VK_ATTACHMENT_LOAD_OP_CLEAR);
-            depthAttachment.storeOp(VK_ATTACHMENT_STORE_OP_DONT_CARE);
-            depthAttachment.stencilLoadOp(VK_ATTACHMENT_LOAD_OP_DONT_CARE);
-            depthAttachment.stencilStoreOp(VK_ATTACHMENT_STORE_OP_DONT_CARE);
+            depthAttachment.loadOp(storeNone ? EXTLoadStoreOpNone.VK_ATTACHMENT_LOAD_OP_NONE_EXT : VK_ATTACHMENT_LOAD_OP_CLEAR);
+            depthAttachment.storeOp(storeNone ? VK13.VK_ATTACHMENT_STORE_OP_NONE : VK_ATTACHMENT_STORE_OP_DONT_CARE);
+            depthAttachment.stencilLoadOp(storeNone ? EXTLoadStoreOpNone.VK_ATTACHMENT_LOAD_OP_NONE_EXT : VK_ATTACHMENT_LOAD_OP_DONT_CARE);
+            depthAttachment.stencilStoreOp(storeNone ? VK13.VK_ATTACHMENT_STORE_OP_NONE : VK_ATTACHMENT_STORE_OP_DONT_CARE);
             depthAttachment.initialLayout(VK_IMAGE_LAYOUT_UNDEFINED);
             depthAttachment.finalLayout(VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
 
@@ -633,13 +657,13 @@ public class Vulkan {
             subpass.pColorAttachments(VkAttachmentReference.callocStack(1, stack).put(0, colorAttachmentRef));
             subpass.pDepthStencilAttachment(depthAttachmentRef);
 
-            VkSubpassDependency.Buffer dependency = VkSubpassDependency.callocStack(1, stack);
-            dependency.srcSubpass(VK_SUBPASS_EXTERNAL);
-            dependency.dstSubpass(0);
-            dependency.srcStageMask(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT);
-            dependency.srcAccessMask(0);
-            dependency.dstStageMask(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT);
-            dependency.dstAccessMask(VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
+//            VkSubpassDependency.Buffer dependency = VkSubpassDependency.callocStack(1, stack);
+//            dependency.srcSubpass(VK_SUBPASS_EXTERNAL);
+//            dependency.dstSubpass(0);
+//            dependency.srcStageMask(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT);
+//            dependency.srcAccessMask(0);
+//            dependency.dstStageMask(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT);
+//            dependency.dstAccessMask(VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
 
             VkRenderPassCreateInfo renderPassInfo = VkRenderPassCreateInfo.callocStack(stack);
             renderPassInfo.sType(VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO);
@@ -667,9 +691,8 @@ public class Vulkan {
             PointerBuffer pDepthImageMemory = stack.mallocPointer(1);
 
             MemoryManager.getInstance().createImage(
-                    swapChainExtent.width(), swapChainExtent.height(), 1,
-                    depthFormat,
-                    VK_IMAGE_TILING_OPTIMAL,
+                    swapChainExtent.width(), swapChainExtent.height(),1,
+                    depthFormat, VK_IMAGE_TILING_OPTIMAL,
                     VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
                     VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
                     pDepthImage,
@@ -726,7 +749,7 @@ public class Vulkan {
         List<VkSurfaceFormatKHR> list = availableFormats.stream().toList();
 
         VkSurfaceFormatKHR format = list.get(0);
-        boolean flag = true;
+        isRGB = true;
 
         for (VkSurfaceFormatKHR availableFormat : list) {
             if (availableFormat.format() == VK_FORMAT_R8G8B8A8_UNORM && availableFormat.colorSpace() == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
@@ -734,11 +757,11 @@ public class Vulkan {
 
             if (availableFormat.format() == VK_FORMAT_B8G8R8A8_UNORM && availableFormat.colorSpace() == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
                 format = availableFormat;
-                flag = false;
+                isRGB = false;
             }
         }
 
-        if(flag) System.out.println("Non-optimal surface format.");
+        if(isRGB) System.out.println("Non-optimal surface format.");
         return format;
     }
 

--- a/src/main/java/net/vulkanmod/vulkan/memory/MemoryManager.java
+++ b/src/main/java/net/vulkanmod/vulkan/memory/MemoryManager.java
@@ -1,9 +1,10 @@
 package net.vulkanmod.vulkan.memory;
 
 import it.unimi.dsi.fastutil.longs.Long2ReferenceOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.vulkanmod.vulkan.Vulkan;
-import net.vulkanmod.vulkan.texture.VulkanImage;
+import net.vulkanmod.vulkan.util.Pair;
 import org.apache.commons.lang3.Validate;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryStack;
@@ -12,6 +13,7 @@ import org.lwjgl.util.vma.VmaAllocationCreateInfo;
 import org.lwjgl.vulkan.*;
 
 import java.nio.LongBuffer;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -28,9 +30,10 @@ public class MemoryManager {
 
     private int currentFrame = 0;
 
-    private ObjectArrayList<Buffer.BufferInfo>[] freeableBuffers = new ObjectArrayList[Frames];
-    private ObjectArrayList<VulkanImage>[] freeableImages = new ObjectArrayList[Frames];
+    private ObjectArrayList<Buffer.BufferInfo>[] freeableBuffers2 = new ObjectArrayList[Frames];
+//    private static Map<Long, Boolean[]> buffersInUse = new HashMap<>();
 
+//    private final LongOpenHashSet buffers = new LongOpenHashSet();
     private final Long2ReferenceOpenHashMap<Buffer> buffers = new Long2ReferenceOpenHashMap<>();
 
     private long deviceMemory = 0;
@@ -40,13 +43,26 @@ public class MemoryManager {
         INSTANCE = this;
 
         for(int i = 0; i < Frames; ++i) {
-            freeableBuffers[i] = new ObjectArrayList<>();
-            freeableImages[i] = new ObjectArrayList<>();
+            freeableBuffers2[i] = new ObjectArrayList<>();
         }
     }
 
     public static MemoryManager getInstance() {
         return INSTANCE;
+    }
+
+    public static void addMemBarrier(VkCommandBuffer handle, int vkAccessShaderReadBit, int vkAccessShaderWriteBit, long storageBuffer, int i, MemoryStack stack) {
+
+        VkBufferMemoryBarrier.Buffer vkBufferMemoryBarrier = VkBufferMemoryBarrier.callocStack(1, stack);
+        vkBufferMemoryBarrier.get(0).sType$Default()
+                .buffer(storageBuffer)
+                .size(i)
+                .srcAccessMask(vkAccessShaderReadBit)
+                .dstAccessMask(vkAccessShaderWriteBit)
+                .dstQueueFamilyIndex(0)
+                .offset(0);
+
+        vkCmdPipelineBarrier(handle, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT | VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, null, vkBufferMemoryBarrier, null);
     }
 
     public void setCurrentFrame(int frame) {
@@ -225,35 +241,16 @@ public class MemoryManager {
 
         checkBuffer(bufferInfo);
 
-        freeableBuffers[currentFrame].add(bufferInfo);
-
-    }
-
-    public void addToFreeable(VulkanImage image) {
-
-        freeableImages[currentFrame].add(image);
+        freeableBuffers2[currentFrame].add(bufferInfo);
 
     }
 
     public void freeBuffers() {
 
-        List<Buffer.BufferInfo> bufferList = freeableBuffers[currentFrame];
+        List<Buffer.BufferInfo> bufferList = freeableBuffers2[currentFrame];
         for(Buffer.BufferInfo bufferInfo : bufferList) {
 
             freeBuffer(bufferInfo);
-        }
-
-        bufferList.clear();
-
-        this.freeImages();
-    }
-
-    private void freeImages() {
-
-        List<VulkanImage> bufferList = freeableImages[currentFrame];
-        for(VulkanImage image : bufferList) {
-
-            freeImage(image.getId(), image.getAllocation());
         }
 
         bufferList.clear();

--- a/src/main/java/net/vulkanmod/vulkan/texture/VulkanImage.java
+++ b/src/main/java/net/vulkanmod/vulkan/texture/VulkanImage.java
@@ -162,7 +162,7 @@ public class VulkanImage {
         if (fence != -1) Synchronization.addFence(fence);
     }
 
-    public static void downloadTexture(int width, int height, long buffer, long image) {
+    public static void downloadTextureAsync(int width, int height, long buffer, long image) {
         try(MemoryStack stack = stackPush()) {
             int imageSize = width * height * 4;
 
@@ -634,10 +634,10 @@ public class VulkanImage {
                     destinationStage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
                 }
                 case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL + VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL -> {
-                    barrier.srcAccessMask(VK_ACCESS_MEMORY_READ_BIT|VK_ACCESS_MEMORY_WRITE_BIT);
-                    barrier.dstAccessMask(VK_ACCESS_MEMORY_READ_BIT|VK_ACCESS_MEMORY_WRITE_BIT);
-                    sourceStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT ;
-                    destinationStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+                    barrier.srcAccessMask(VK_ACCESS_UNIFORM_READ_BIT);
+                    barrier.dstAccessMask(VK_ACCESS_SHADER_WRITE_BIT);
+                    sourceStage = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT ;
+                    destinationStage = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
                 }
                 case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL + VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL -> {
                     barrier.srcAccessMask(VK_ACCESS_TRANSFER_WRITE_BIT);

--- a/src/main/resources/assets/vulkanmod/shaders/extra/swizzle.csh
+++ b/src/main/resources/assets/vulkanmod/shaders/extra/swizzle.csh
@@ -1,0 +1,35 @@
+#version 460
+#pragma shader_stage(compute)
+
+layout (local_size_x = 32) in;
+
+
+layout(std430, binding = 0) restrict buffer Img
+{
+   uvec4 imageData[];
+};
+
+const uvec4 A = uvec4(255<<24);
+
+void main()
+{
+	const uint xx=gl_GlobalInvocationID.x*32;
+	//const uint yy=gl_GlobalInvocationID.y*WORKGROUP_SIZE;
+	
+	
+	for(uint xOffs=xx;xOffs<xx+32;xOffs++)
+	{
+		
+		{
+			const uvec4 R = (imageData[xOffs]&255)<<16;
+			const uvec4 G = (imageData[xOffs]&65535)>>8<<8;
+			const uvec4 B = (imageData[xOffs]&16777215)>>16;
+			
+			imageData[xOffs]=(R|G|B|A);
+		}
+	}
+	
+	
+	
+	
+}

--- a/src/main/resources/assets/vulkanmod/shaders/extra/swizzle.csh
+++ b/src/main/resources/assets/vulkanmod/shaders/extra/swizzle.csh
@@ -4,16 +4,15 @@
 layout (local_size_x = 32, local_size_y = 32) in;
 
 
-layout(binding = 0, rgba8ui) uniform restrict uimage2D Img;
+layout(binding = 0, rgba8) uniform restrict image2D Img;
 
 //const uint defSize=1u;
-const uvec4 A = uvec4(255<<24);
+const uint A = 255u;
 
 void main()
 {
-	const uint xx = (gl_GlobalInvocationID.x);
-	const uint yy = (gl_GlobalInvocationID.y);
-	//const uint yy=gl_GlobalInvocationID.y*WORKGROUP_SIZE;
+	const ivec2 xy = ivec2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y);
+	
 	
 	
 	//for(int xOffs=xx;xOffs<xx+defSize;xOffs++)
@@ -23,7 +22,7 @@ void main()
 		{
 		
 			
-			imageStore(Img, ivec2(xx, yy), imageLoad(Img, ivec2(xx, yy)).bgra);
+			imageStore(Img, xy, vec4(imageLoad(Img, xy).bgr, A));
 		}
 	}
 	

--- a/src/main/resources/assets/vulkanmod/shaders/extra/swizzle.csh
+++ b/src/main/resources/assets/vulkanmod/shaders/extra/swizzle.csh
@@ -1,31 +1,29 @@
 #version 460
 #pragma shader_stage(compute)
 
-layout (local_size_x = 32) in;
+layout (local_size_x = 32, local_size_y = 32) in;
 
 
-layout(std430, binding = 0) restrict buffer Img
-{
-   uvec4 imageData[];
-};
+layout(binding = 0, rgba8ui) uniform restrict uimage2D Img;
 
+//const uint defSize=1u;
 const uvec4 A = uvec4(255<<24);
 
 void main()
 {
-	const uint xx=gl_GlobalInvocationID.x*32;
+	const uint xx = (gl_GlobalInvocationID.x);
+	const uint yy = (gl_GlobalInvocationID.y);
 	//const uint yy=gl_GlobalInvocationID.y*WORKGROUP_SIZE;
 	
 	
-	for(uint xOffs=xx;xOffs<xx+32;xOffs++)
+	//for(int xOffs=xx;xOffs<xx+defSize;xOffs++)
 	{
 		
+		//for(int yOffs=yy; yOffs<yy+defSize; yOffs++)
 		{
-			const uvec4 R = (imageData[xOffs]&255)<<16;
-			const uvec4 G = (imageData[xOffs]&65535)>>8<<8;
-			const uvec4 B = (imageData[xOffs]&16777215)>>16;
+		
 			
-			imageData[xOffs]=(R|G|B|A);
+			imageStore(Img, ivec2(xx, yy), imageLoad(Img, ivec2(xx, yy)).bgra);
 		}
 	}
 	

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "vulkanmod",
-  "version": "0.2.2",
+  "version": "0.2.1",
 
   "name": "VulkanMod",
   "description": "Bring Vulkan to Minecraft!",
@@ -24,7 +24,7 @@
   "mixins": [
     "vulkanmod.mixins.json"
   ],
-  "accessWidener" : "vulkanmod.accesswidener",
+  "accessWidener" : "vulkanmod.accesswidener.old",
 
   "depends": {
     "fabricloader": ">=0.13.3",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "vulkanmod",
-  "version": "0.2.1",
+  "version": "0.2.2",
 
   "name": "VulkanMod",
   "description": "Bring Vulkan to Minecraft!",
@@ -15,9 +15,9 @@
 
   "icon": "assets/vulkanmod/Vlogo.png",
 
-  "environment": "*",
+  "environment": "client",
   "entrypoints": {
-    "main": [
+    "client": [
       "net.vulkanmod.Initializer"
     ]
   },

--- a/src/main/resources/vulkanmod.accesswidener
+++ b/src/main/resources/vulkanmod.accesswidener
@@ -2,3 +2,4 @@ accessWidener	v1	named
 
 accessible field net/minecraft/client/renderer/LevelRenderer$RenderChunkInfo chunk Lnet/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk;
 accessible class net/minecraft/client/gui/Gui$HeartType
+accessible field com/mojang/blaze3d/platform/NativeImage pixels J

--- a/src/main/resources/vulkanmod.accesswidener.old
+++ b/src/main/resources/vulkanmod.accesswidener.old
@@ -1,0 +1,4 @@
+accessWidener	v1	named
+#Accessible class net/minecraft/client/render/WorldRenderer$ChunkInfo
+accessible field net/minecraft/client/render/WorldRenderer$ChunkInfo chunk Lnet/minecraft/client/render/chunk/ChunkBuilder$BuiltChunk;
+accessible class net/minecraft/client/gui/hud/InGameHud$HeartType


### PR DESCRIPTION
_(Had to close my old account due to some privacy issues hence why this is reuploaded)_

This PR attempts to fix an old bug in the mod where the screenshot colours are not converted to the correct RGB pixel format prior to saving the Framebuffer/Swapchain image as a .png file.

This is done through a separate Compute Shader to Swizzle the Pixel colour channels when saving/handling the screenshot, and due to how the compute step is handled should have no effects on gameplay or performance in any tangible way.