### PR TITLE
(Possibly Invalid) - Fix V-Sync with Nvidia when in exclusive FullScreen

### DIFF
--- a/src/main/java/net/vulkanmod/vulkan/Vulkan.java
+++ b/src/main/java/net/vulkanmod/vulkan/Vulkan.java
@@ -181,7 +181,7 @@ public class Vulkan {
 
     private static long allocator;
 
-    private static boolean vsync = false;
+    public static boolean vsync = false;
 
     private static StagingBuffer[] stagingBuffers;
     private static MemoryManager memoryManager;

--- a/src/main/java/net/vulkanmod/vulkan/shader/Pipeline.java
+++ b/src/main/java/net/vulkanmod/vulkan/shader/Pipeline.java
@@ -580,12 +580,13 @@ public class Pipeline {
                     ++i;
                 }
 
-                VkDescriptorImageInfo.Buffer imageInfos = VkDescriptorImageInfo.calloc(samplers.size(), stack);
                 //Don't create empty CommandbUffer if samplers are empty
                 if(!samplers.isEmpty())
                 {
+                    VkDescriptorImageInfo.Buffer imageInfos = VkDescriptorImageInfo.malloc(samplers.size(), stack);
                     TransferQueue.CommandBuffer commandBuffer = TransferQueue.beginCommands();
-                    for (int j=0; j<samplers.size(); j++) {
+                    int j=0;
+                    for (final VkDescriptorImageInfo imageInfo : imageInfos) {
 
                         //TODO: make an auxiliary function
                         VulkanImage texture = getTex(j);
@@ -593,20 +594,21 @@ public class Pipeline {
                         texture.readOnlyLayout(commandBuffer);
                         //VulkanImage texture = VTextureManager.getCurrentTexture();
 
-                        VkDescriptorImageInfo imageInfo = imageInfos.get(j);
+
                         imageInfo.imageLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
                         imageInfo.imageView(texture.getTextureImageView());
                         imageInfo.sampler(texture.getTextureSampler());
 
                         VkWriteDescriptorSet samplerDescriptorWrite = descriptorWrites.get(i);
-                        samplerDescriptorWrite.sType(VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET);
+                        samplerDescriptorWrite.sType$Default();
                         samplerDescriptorWrite.dstBinding(i);
                         samplerDescriptorWrite.dstArrayElement(0);
                         samplerDescriptorWrite.descriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
                         samplerDescriptorWrite.descriptorCount(1);
                         memPutAddress(samplerDescriptorWrite.address() + VkWriteDescriptorSet.PIMAGEINFO, imageInfo.address());
                         ++i;
+                        ++j;
 
                     }
                     long fence = TransferQueue.endCommands(commandBuffer);

--- a/src/main/java/net/vulkanmod/vulkan/shader/Pipeline.java
+++ b/src/main/java/net/vulkanmod/vulkan/shader/Pipeline.java
@@ -581,6 +581,7 @@ public class Pipeline {
                 }
 
                 //Don't create empty CommandbUffer if samplers are empty
+                VkDescriptorImageInfo.Buffer imageInfos = VkDescriptorImageInfo.malloc(samplers.size(), stack);
                 if(!samplers.isEmpty())
                 {
                     VkDescriptorImageInfo.Buffer imageInfos = VkDescriptorImageInfo.malloc(samplers.size(), stack);
@@ -611,8 +612,11 @@ public class Pipeline {
                         ++j;
 
                     }
-                    long fence = TransferQueue.endCommands(commandBuffer);
-                    if (fence != 0) Synchronization.addFence(fence);
+                    if(Vulkan.vsync) //Nvidia has issues with Sampler updates with V-Sync for some reason
+                    {
+                        long fence = TransferQueue.endCommands(commandBuffer);
+                        if (fence != 0) Synchronization.addFence(fence);
+                    }
                 }
 
                 //long descriptorSet = descriptorSets.get(Drawer.getCurrentFrame());

--- a/src/main/java/net/vulkanmod/vulkan/texture/VulkanImage.java
+++ b/src/main/java/net/vulkanmod/vulkan/texture/VulkanImage.java
@@ -15,7 +15,6 @@ import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
 
 import static net.vulkanmod.vulkan.Vulkan.*;
-import static net.vulkanmod.vulkan.memory.MemoryManager.*;
 import static org.lwjgl.system.MemoryStack.stackPush;
 import static org.lwjgl.vulkan.VK10.*;
 
@@ -225,10 +224,8 @@ public class VulkanImage {
         currentLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
     }
 
-    public void readOnlyLayout() {
+    public void readOnlyLayout(TransferQueue.CommandBuffer commandBuffer) {
         if (this.currentLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) return;
-
-        TransferQueue.CommandBuffer commandBuffer = TransferQueue.beginCommands();
 
         try(MemoryStack stack = stackPush()) {
 
@@ -263,10 +260,6 @@ public class VulkanImage {
                     null,
                     barrier);
         }
-
-        long fence = TransferQueue.endCommands(commandBuffer);
-        if (fence != 0) Synchronization.addFence(fence);
-
 
         this.currentLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     }


### PR DESCRIPTION
This is a very simple/small PR that seems to fix an odd issue specific to Nvidia cards where in exclusive fullscreen, the frametime is extremely poor and unstable, and is practically unplayable unless exiting fullscreen or uncapping/disabling V-Sync completely.

This could possibly be due to my setup/Buggy Nvidia driver version, however decided to release it just in case it actually helps anyone else in anyway. (Or gives an actual/tangible performance/stability improvement)