### PR TITLE
Add Driver and Vulkan version fields to the Debug Screen

### DIFF
--- a/src/main/java/net/vulkanmod/mixin/debug/DebugHudM.java
+++ b/src/main/java/net/vulkanmod/mixin/debug/DebugHudM.java
@@ -67,6 +67,7 @@ public abstract class DebugHudM {
         strings.add("CPU: " + DeviceInfo.cpuInfo);
         strings.add("GPU: " + Vulkan.getDeviceInfo().deviceName);
         strings.add("Driver: " + Vulkan.getDeviceInfo().driverVersion);
+        strings.add("Vulkan: " + Vulkan.getDeviceInfo().vkVersion);
         strings.add("");
 
         return strings;

--- a/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
+++ b/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
@@ -85,9 +85,8 @@ public class DeviceInfo {
         return switch (i) {
             case (0x10DE) -> "Nvidia";
             case (0x1022) -> "AMD";
-            case (0x5143) -> "Qualcomm";
             case (0x8086) -> "Intel";
-            default -> "undef"; //Either AMD or Unknown Driver version/vendor and.or Encoding Scheme
+            default -> "undef"; //Either AMD or Unknown Driver version/vendor and/or Encoding Scheme
         };
     }
 
@@ -96,6 +95,7 @@ public class DeviceInfo {
     static String decDefVersion(int v) {
         return VK_VERSION_MAJOR(v) + "." + VK_VERSION_MINOR(v) + "." + VK_VERSION_PATCH(v);
     }
+    
     //0x10DE = Nvidia: https://pcisig.com/membership/member-companies?combine=Nvidia
     //https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceProperties.html
     //this should work with Nvidia + AMD but is not guaranteed to work with intel drivers in Windows and more obscure/Exotic Drivers/vendors
@@ -103,14 +103,9 @@ public class DeviceInfo {
         return switch (i) {
             case (0x10DE) -> decodeNvidia(v); //Nvidia
             case (0x1022) -> decDefVersion(v); //AMD
-            case (0x5143) -> decQualCommVersion(v); //Qualcomm
             case (0x8086) -> decIntelVersion(v); //Intel
             default -> decDefVersion(v); //Either AMD or Unknown Driver version/vendor and.or Encoding Scheme
         };
-    }
-
-    private static String decQualCommVersion(int v) {
-        return null;
     }
 
     //Source: https://www.intel.com/content/www/us/en/support/articles/000005654/graphics.html

--- a/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
+++ b/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
@@ -17,9 +17,11 @@ import java.util.Objects;
 import java.util.Set;
 
 import static java.util.stream.Collectors.toSet;
+import static org.lwjgl.glfw.GLFW.GLFW_PLATFORM_WIN32;
+import static org.lwjgl.glfw.GLFW.glfwGetPlatform;
 import static org.lwjgl.system.MemoryStack.stackPush;
 import static org.lwjgl.vulkan.VK10.*;
-import static org.lwjgl.vulkan.VK10.VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
+import static org.lwjgl.vulkan.VK11.*;
 
 public class DeviceInfo {
 
@@ -30,10 +32,14 @@ public class DeviceInfo {
     public final String vendorId;
     public final String deviceName;
     public final String driverVersion;
-
+    public final String vkVersion;
     public GraphicsCard graphicsCard;
 
-    public final VkPhysicalDeviceFeatures availableFeatures;
+    public final VkPhysicalDeviceFeatures2 availableFeatures;
+    public final VkPhysicalDeviceVulkan11Features availableFeatures11;
+
+//    public final VkPhysicalDeviceVulkan12Features availableFeatures12;
+//    public final boolean vulkan13Support;
 
     static {
         CentralProcessor centralProcessor = new SystemInfo().getHardware().getProcessor();
@@ -49,12 +55,74 @@ public class DeviceInfo {
         }
 
         this.device = device;
-        this.vendorId = String.valueOf(properties.vendorID());
+        this.vendorId = decodeVendor(properties.vendorID());
         this.deviceName = properties.deviceNameString();
-        this.driverVersion = String.valueOf(properties.driverVersion());
+        this.driverVersion = decodeDvrVersion(Vulkan.deviceProperties.driverVersion(), Vulkan.deviceProperties.vendorID());
+        this.vkVersion = decDefVersion(Vulkan.vkVer);
 
-        this.availableFeatures = VkPhysicalDeviceFeatures.malloc();
-        vkGetPhysicalDeviceFeatures(this.device, this.availableFeatures);
+        this.availableFeatures = VkPhysicalDeviceFeatures2.calloc();
+        this.availableFeatures.sType$Default();
+
+
+        this.availableFeatures11 = VkPhysicalDeviceVulkan11Features.malloc();
+        this.availableFeatures11.sType$Default();
+
+
+        this.availableFeatures.pNext(this.availableFeatures11);
+
+        //Vulkan 1.3
+//        this.availableFeatures13 = VkPhysicalDeviceVulkan13Features.malloc();
+//        this.availableFeatures13.sType$Default();
+//        this.availableFeatures11.pNext(this.availableFeatures13.address());
+//
+//        this.vulkan13Support = this.device.getCapabilities().apiVersion == VK_API_VERSION_1_3;
+
+        vkGetPhysicalDeviceFeatures2(this.device, this.availableFeatures);
+
+    }
+
+    private static String decodeVendor(int i) {
+        return switch (i) {
+            case (0x10DE) -> "Nvidia";
+            case (0x1022) -> "AMD";
+            case (0x5143) -> "Qualcomm";
+            case (0x8086) -> "Intel";
+            default -> "undef"; //Either AMD or Unknown Driver version/vendor and.or Encoding Scheme
+        };
+    }
+
+    //Should Work with AMD: https://gpuopen.com/learn/decoding-radeon-vulkan-versions/
+
+    static String decDefVersion(int v) {
+        return VK_VERSION_MAJOR(v) + "." + VK_VERSION_MINOR(v) + "." + VK_VERSION_PATCH(v);
+    }
+    //0x10DE = Nvidia: https://pcisig.com/membership/member-companies?combine=Nvidia
+    //https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceProperties.html
+    //this should work with Nvidia + AMD but is not guaranteed to work with intel drivers in Windows and more obscure/Exotic Drivers/vendors
+    private static String decodeDvrVersion(int v, int i) {
+        return switch (i) {
+            case (0x10DE) -> decodeNvidia(v); //Nvidia
+            case (0x1022) -> decDefVersion(v); //AMD
+            case (0x5143) -> decQualCommVersion(v); //Qualcomm
+            case (0x8086) -> decIntelVersion(v); //Intel
+            default -> decDefVersion(v); //Either AMD or Unknown Driver version/vendor and.or Encoding Scheme
+        };
+    }
+
+    private static String decQualCommVersion(int v) {
+        return null;
+    }
+
+    //Source: https://www.intel.com/content/www/us/en/support/articles/000005654/graphics.html
+    //Won't Work with older Drivers (15.45 And.or older)
+    //May not work as this uses Guess work+Assumptions
+    private static String decIntelVersion(int v) {
+        return (glfwGetPlatform()==GLFW_PLATFORM_WIN32) ? (v >>> 14) + "." + (v & 0x3fff) : decDefVersion(v);
+    }
+
+
+    private static String decodeNvidia(int v) {
+        return (v >>> 22 & 0x3FF) + "." + (v >>> 14 & 0xff) + "." + (v >>> 6 & 0xff) + "." + (v & 0xff);
     }
 
     private String unsupportedExtensions(Set<String> requiredExtensions) {


### PR DESCRIPTION
This is a quick PR that allows the GPU Driver and Vulkan version to be decoded from binary format into a human readable version number, which is visible at any time when using the Debug Screen with F3.

This supports displaying the Driver versions for AMD, Nvidia and Intel. Other vendors may also work, but are not 100% guaranteed to display the driver version correctly.

Below example showing how it appears with a GTX 1080 Ti running Driver version 473.64.

![2023-08-25_16 52 14](https://github.com/xCollateral/VulkanMod/assets/125277899/0d6424fe-f20d-41ed-ae88-08398639838f)
