### PR TITLE
Add Vulkan and GPU Driver versions to Debug Screen

### DIFF
--- a/src/main/java/net/vulkanmod/mixin/debug/DebugScreenOverlayM.java
+++ b/src/main/java/net/vulkanmod/mixin/debug/DebugScreenOverlayM.java
@@ -68,6 +68,7 @@ public abstract class DebugScreenOverlayM {
         strings.add("CPU: " + DeviceInfo.cpuInfo);
         strings.add("GPU: " + Vulkan.getDeviceInfo().deviceName);
         strings.add("Driver: " + Vulkan.getDeviceInfo().driverVersion);
+        strings.add("Vulkan: " + Vulkan.getDeviceInfo().vkVersion);
         strings.add("");
 
         return strings;

--- a/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
+++ b/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
@@ -93,7 +93,6 @@ public class DeviceInfo {
         return switch (i) {
             case (0x10DE) -> "Nvidia";
             case (0x1022) -> "AMD";
-            case (0x5143) -> "Qualcomm";
             case (0x8086) -> "Intel";
             default -> "undef"; //Either AMD or Unknown Driver version/vendor and.or Encoding Scheme
         };
@@ -111,14 +110,9 @@ public class DeviceInfo {
         return switch (i) {
             case (0x10DE) -> decodeNvidia(v); //Nvidia
             case (0x1022) -> decDefVersion(v); //AMD
-            case (0x5143) -> decQualCommVersion(v); //Qualcomm
             case (0x8086) -> decIntelVersion(v); //Intel
-            default -> decDefVersion(v); //Either AMD or Unknown Driver version/vendor and.or Encoding Scheme
+            default -> decDefVersion(v); //Either AMD or Unknown Driver Encoding Scheme
         };
-    }
-
-    private static String decQualCommVersion(int v) {
-        return null;
     }
 
     //Source: https://www.intel.com/content/www/us/en/support/articles/000005654/graphics.html

--- a/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
+++ b/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
@@ -18,13 +18,10 @@ import static net.vulkanmod.vulkan.SwapChain.querySwapChainSupport;
 import static org.lwjgl.system.MemoryStack.stackPush;
 import static org.lwjgl.vulkan.VK10.vkEnumerateDeviceExtensionProperties;
 import static org.lwjgl.vulkan.VK10.vkGetPhysicalDeviceProperties;
-import static org.lwjgl.vulkan.VK11.VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
 import static org.lwjgl.vulkan.VK11.vkGetPhysicalDeviceFeatures2;
-import static org.lwjgl.vulkan.VK13.VK_API_VERSION_1_3;
 
 import static org.lwjgl.glfw.GLFW.GLFW_PLATFORM_WIN32;
 import static org.lwjgl.glfw.GLFW.glfwGetPlatform;
-import static org.lwjgl.system.MemoryStack.stackPush;
 import static org.lwjgl.vulkan.VK10.*;
 import static org.lwjgl.vulkan.VK11.*;
 
@@ -65,7 +62,7 @@ public class DeviceInfo {
         this.vendorId = decodeVendor(properties.vendorID());
         this.deviceName = properties.deviceNameString();
         this.driverVersion = decodeDvrVersion(Vulkan.deviceProperties.driverVersion(), Vulkan.deviceProperties.vendorID());
-        this.vkVersion = decDefVersion(Vulkan.vkVer);
+        this.vkVersion = decDefVersion(getVkVer());
 
 //        this.driverVersion = graphicsCard.getVersionInfo();
 
@@ -125,6 +122,20 @@ public class DeviceInfo {
 
     private static String decodeNvidia(int v) {
         return (v >>> 22 & 0x3FF) + "." + (v >>> 14 & 0xff) + "." + (v >>> 6 & 0xff) + "." + (v & 0xff);
+    }
+
+    static int getVkVer() {
+        try(MemoryStack stack = MemoryStack.stackPush())
+        {
+            var a = stack.mallocInt(1);
+            vkEnumerateInstanceVersion(a);
+            int vkVer1 = a.get(0);
+            if(VK_VERSION_MINOR(vkVer1)<2)
+            {
+                throw new RuntimeException("Vulkan 1.2 not supported!: "+"Only Has: "+ decDefVersion(vkVer1));
+            }
+            return vkVer1;
+        }
     }
 
     private String unsupportedExtensions(Set<String> requiredExtensions) {

--- a/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
+++ b/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
@@ -22,6 +22,12 @@ import static org.lwjgl.vulkan.VK11.VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2
 import static org.lwjgl.vulkan.VK11.vkGetPhysicalDeviceFeatures2;
 import static org.lwjgl.vulkan.VK13.VK_API_VERSION_1_3;
 
+import static org.lwjgl.glfw.GLFW.GLFW_PLATFORM_WIN32;
+import static org.lwjgl.glfw.GLFW.glfwGetPlatform;
+import static org.lwjgl.system.MemoryStack.stackPush;
+import static org.lwjgl.vulkan.VK10.*;
+import static org.lwjgl.vulkan.VK11.*;
+
 public class DeviceInfo {
 
     public static final String cpuInfo;
@@ -31,7 +37,7 @@ public class DeviceInfo {
     public final String vendorId;
     public final String deviceName;
     public final String driverVersion;
-
+    public final String vkVersion;
     public GraphicsCard graphicsCard;
 
     public final VkPhysicalDeviceFeatures2 availableFeatures;
@@ -56,9 +62,10 @@ public class DeviceInfo {
         }
 
         this.device = device;
-        this.vendorId = String.valueOf(properties.vendorID());
+        this.vendorId = decodeVendor(properties.vendorID());
         this.deviceName = properties.deviceNameString();
-        this.driverVersion = String.valueOf(properties.driverVersion());
+        this.driverVersion = decodeDvrVersion(Vulkan.deviceProperties.driverVersion(), Vulkan.deviceProperties.vendorID());
+        this.vkVersion = decDefVersion(Vulkan.vkVer);
 
 //        this.driverVersion = graphicsCard.getVersionInfo();
 
@@ -80,7 +87,50 @@ public class DeviceInfo {
 
         if(this.availableFeatures.features().multiDrawIndirect() && this.availableFeatures11.shaderDrawParameters())
                 this.drawIndirectSupported = true;
+    }
 
+    private static String decodeVendor(int i) {
+        return switch (i) {
+            case (0x10DE) -> "Nvidia";
+            case (0x1022) -> "AMD";
+            case (0x5143) -> "Qualcomm";
+            case (0x8086) -> "Intel";
+            default -> "undef"; //Either AMD or Unknown Driver version/vendor and.or Encoding Scheme
+        };
+    }
+
+    //Should Work with AMD: https://gpuopen.com/learn/decoding-radeon-vulkan-versions/
+
+    static String decDefVersion(int v) {
+        return VK_VERSION_MAJOR(v) + "." + VK_VERSION_MINOR(v) + "." + VK_VERSION_PATCH(v);
+    }
+    //0x10DE = Nvidia: https://pcisig.com/membership/member-companies?combine=Nvidia
+    //https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceProperties.html
+    //this should work with Nvidia + AMD but is not guaranteed to work with intel drivers in Windows and more obscure/Exotic Drivers/vendors
+    private static String decodeDvrVersion(int v, int i) {
+        return switch (i) {
+            case (0x10DE) -> decodeNvidia(v); //Nvidia
+            case (0x1022) -> decDefVersion(v); //AMD
+            case (0x5143) -> decQualCommVersion(v); //Qualcomm
+            case (0x8086) -> decIntelVersion(v); //Intel
+            default -> decDefVersion(v); //Either AMD or Unknown Driver version/vendor and.or Encoding Scheme
+        };
+    }
+
+    private static String decQualCommVersion(int v) {
+        return null;
+    }
+
+    //Source: https://www.intel.com/content/www/us/en/support/articles/000005654/graphics.html
+    //Won't Work with older Drivers (15.45 And.or older)
+    //May not work as this uses Guess work+Assumptions
+    private static String decIntelVersion(int v) {
+        return (glfwGetPlatform()==GLFW_PLATFORM_WIN32) ? (v >>> 14) + "." + (v & 0x3fff) : decDefVersion(v);
+    }
+
+
+    private static String decodeNvidia(int v) {
+        return (v >>> 22 & 0x3FF) + "." + (v >>> 14 & 0xff) + "." + (v >>> 6 & 0xff) + "." + (v & 0xff);
     }
 
     private String unsupportedExtensions(Set<String> requiredExtensions) {

--- a/src/main/java/net/vulkanmod/vulkan/Vulkan.java
+++ b/src/main/java/net/vulkanmod/vulkan/Vulkan.java
@@ -37,9 +37,9 @@ import static org.lwjgl.vulkan.EXTDebugUtils.*;
 import static org.lwjgl.vulkan.KHRDynamicRendering.VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME;
 import static org.lwjgl.vulkan.KHRSwapchain.VK_KHR_SWAPCHAIN_EXTENSION_NAME;
 import static org.lwjgl.vulkan.VK10.*;
-import static org.lwjgl.vulkan.VK12.VK_API_VERSION_1_2;
 import static org.lwjgl.vulkan.VK11.VK_API_VERSION_1_1;
 import static org.lwjgl.vulkan.VK11.vkEnumerateInstanceVersion;
+import static org.lwjgl.vulkan.VK12.VK_API_VERSION_1_2;
 
 public class Vulkan {
 
@@ -47,7 +47,6 @@ public class Vulkan {
 //    public static final boolean ENABLE_VALIDATION_LAYERS = true;
 
     public static final Set<String> VALIDATION_LAYERS;
-    public static final int vkVer = getVkVer();
 
     static {
         if(ENABLE_VALIDATION_LAYERS) {
@@ -64,19 +63,6 @@ public class Vulkan {
     private static final Set<String> DEVICE_EXTENSIONS = Stream.of(
                     VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME)
             .collect(toSet());
-    private static int getVkVer() {
-        try(MemoryStack stack = MemoryStack.stackPush())
-        {
-            var a = stack.mallocInt(1);
-            vkEnumerateInstanceVersion(a);
-            int vkVer1 = a.get(0);
-            if(VK_VERSION_MINOR(vkVer1)<2)
-            {
-                throw new RuntimeException("Vulkan 1.2 not supported!: "+"Only Has: "+ DeviceInfo.decDefVersion(vkVer1));
-            }
-            return vkVer1;
-        }
-    }
 
 
     private static int debugCallback(int messageSeverity, int messageType, long pCallbackData, long pUserData) {
@@ -249,7 +235,7 @@ public class Vulkan {
             appInfo.applicationVersion(VK_MAKE_VERSION(1, 0, 0));
             appInfo.pEngineName(stack.UTF8Safe("No Engine"));
             appInfo.engineVersion(VK_MAKE_VERSION(1, 0, 0));
-            appInfo.apiVersion(vkVer);
+            appInfo.apiVersion(VK_API_VERSION_1_2);
 
             VkInstanceCreateInfo createInfo = VkInstanceCreateInfo.callocStack(stack);
 
@@ -460,7 +446,7 @@ public class Vulkan {
                 throw new RuntimeException("Failed to create logical device");
             }
 
-            device = new VkDevice(pDevice.get(0), physicalDevice, createInfo, vkVer);
+            device = new VkDevice(pDevice.get(0), physicalDevice, createInfo, VK_API_VERSION_1_2);
 
             PointerBuffer pQueue = stack.pointers(VK_NULL_HANDLE);
 
@@ -487,7 +473,7 @@ public class Vulkan {
             allocatorCreateInfo.device(device);
             allocatorCreateInfo.pVulkanFunctions(vulkanFunctions);
             allocatorCreateInfo.instance(instance);
-            allocatorCreateInfo.vulkanApiVersion(vkVer);
+            allocatorCreateInfo.vulkanApiVersion(VK_API_VERSION_1_2);
 
             PointerBuffer pAllocator = stack.pointers(VK_NULL_HANDLE);
 

--- a/src/main/java/net/vulkanmod/vulkan/Vulkan.java
+++ b/src/main/java/net/vulkanmod/vulkan/Vulkan.java
@@ -460,7 +460,7 @@ public class Vulkan {
                 throw new RuntimeException("Failed to create logical device");
             }
 
-            device = new VkDevice(pDevice.get(0), physicalDevice, createInfo, VK_API_VERSION_1_2);
+            device = new VkDevice(pDevice.get(0), physicalDevice, createInfo, vkVer);
 
             PointerBuffer pQueue = stack.pointers(VK_NULL_HANDLE);
 


### PR DESCRIPTION
This is a quick PR that allows the GPU Driver and Vulkan version to be decoded from binary format into a human readable version number, which is visible at any time when using the Debug Screen with F3.

This supports displaying the Driver versions for AMD, Nvidia and Intel. 
Other vendors may also work, but are not 100% guaranteed to display the driver version correctly.

(Example with a GTX 1080 Ti Running Driver Version 473.64 on Vulkan 1.3.211)
![2023-08-25_17 31 15](https://github.com/xCollateral/VulkanMod/assets/125277899/cc796a2f-c86f-4aa7-bd4c-13ae96567e96)
