### PR TITLE
Use IDENTITY preTransform instead of currentTransform

### DIFF
--- a/src/main/java/net/vulkanmod/vulkan/framebuffer/SwapChain.java
+++ b/src/main/java/net/vulkanmod/vulkan/framebuffer/SwapChain.java
@@ -129,7 +129,7 @@ public class SwapChain extends Framebuffer {
                 createInfo.imageSharingMode(VK_SHARING_MODE_EXCLUSIVE);
             }
 
-            createInfo.preTransform(surfaceProperties.capabilities.currentTransform());
+            createInfo.preTransform(VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
             createInfo.compositeAlpha(VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR);
             createInfo.presentMode(presentMode);
             createInfo.clipped(true);


### PR DESCRIPTION
This fixes the issue with the output being rotated when using SurfaceView on Android.
Before:
![Screenshot_20230918-114259_PojavLauncher (Minecraft_ Java Edition для Android)](https://github.com/xCollateral/VulkanMod/assets/45949002/1d3386aa-7419-4b6d-873a-0fc68d06075c)
After:
![Screenshot_20230918-114401_PojavLauncher (Minecraft_ Java Edition для Android)](https://github.com/xCollateral/VulkanMod/assets/45949002/4d09ba49-6bbe-4ed9-9b10-a68ed83a6672)
