### PR TITLE
Rewrite the optimisations to cubes to be more compatible with mods th…

### DIFF
--- a/src/main/java/net/vulkanmod/interfaces/ModelPartCubeMixed.java
+++ b/src/main/java/net/vulkanmod/interfaces/ModelPartCubeMixed.java
@@ -1,8 +1,11 @@
 package net.vulkanmod.interfaces;
 
+import net.minecraft.client.model.geom.ModelPart.Polygon;
 import net.vulkanmod.render.model.CubeModel;
 
 public interface ModelPartCubeMixed {
 
     CubeModel getCubeModel();
+
+    Polygon[] getPolygons();
 }

--- a/src/main/java/net/vulkanmod/mixin/gui/DebugHudM.java
+++ b/src/main/java/net/vulkanmod/mixin/gui/DebugHudM.java
@@ -5,7 +5,7 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.Tesselator;
-import com.mojang.blaze3d.vertex.VertexFormat;;
+import com.mojang.blaze3d.vertex.VertexFormat;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;

--- a/src/main/java/net/vulkanmod/mixin/render/model/ModelPartCubeM.java
+++ b/src/main/java/net/vulkanmod/mixin/render/model/ModelPartCubeM.java
@@ -1,34 +1,25 @@
 package net.vulkanmod.mixin.render.model;
 
 import net.minecraft.client.model.geom.ModelPart;
-import net.minecraft.core.Direction;
+import net.minecraft.client.model.geom.ModelPart.Polygon;
 import net.vulkanmod.interfaces.ModelPartCubeMixed;
 import net.vulkanmod.render.model.CubeModel;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.Set;
+import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(ModelPart.Cube.class)
-public class ModelPartCubeM implements ModelPartCubeMixed {
-
-    CubeModel cube;
-
-    @Inject(method = "<init>", at = @At(value = "FIELD",
-            target = "Lnet/minecraft/client/model/geom/ModelPart$Cube;polygons:[Lnet/minecraft/client/model/geom/ModelPart$Polygon;",
-            ordinal = 0, shift = At.Shift.AFTER))
-    private void getVertices(int i, int j, float f, float g, float h, float k, float l, float m, float n, float o, float p, boolean bl, float q, float r, Set<Direction> set, CallbackInfo ci) {
-        //TODO check if set is needed
-        CubeModel cube = new CubeModel();
-        cube.setVertices(i, j, f, g, h, k, l, m, n, o, p, bl, q, r);
-        this.cube = cube;
-    }
-
+abstract class ModelPartCubeM implements ModelPartCubeMixed {
+    private CubeModel cube;
 
     @Override
     public CubeModel getCubeModel() {
+        if (this.cube == null) {
+            this.cube = new CubeModel();
+        }
         return this.cube;
     }
+
+    @Override
+    @Accessor
+    public abstract Polygon[] getPolygons();
 }

--- a/src/main/java/net/vulkanmod/mixin/render/model/ModelPartM.java
+++ b/src/main/java/net/vulkanmod/mixin/render/model/ModelPartM.java
@@ -38,17 +38,19 @@ public class ModelPartM {
             ModelPartCubeMixed cubeMixed = (ModelPartCubeMixed)(cube);
             CubeModel cubeModel = cubeMixed.getCubeModel();
 
-            ModelPart.Polygon[] var11 = cubeModel.getPolygons();
+            ModelPart.Polygon[] var11 = cubeMixed.getPolygons();
+
+            cubeModel.compileVertices(var11);
+            cubeModel.transformVertices(matrix4f, matrix3f);
+
 //            int var12 = var11.length;
 
-            cubeModel.transformVertices(matrix4f);
-
             for (ModelPart.Polygon polygon : var11) {
-                Vector3f vector3f = matrix3f.transform(new Vector3f(polygon.normal));
+                //Vector3f vector3f = matrix3f.transform(new Vector3f(polygon.normal));
 //                float l = vector3f.x();
 //                float m = vector3f.y();
 //                float n = vector3f.z();
-                int packedNormal = VertexUtil.packNormal(vector3f.x(), vector3f.y(), vector3f.z());
+                int packedNormal = VertexUtil.packNormal(polygon.normal.x(), polygon.normal.y(), polygon.normal.z());
 
                 ModelPart.Vertex[] vertices = polygon.vertices;
 //                int var20 = vertices.length;

--- a/src/main/java/net/vulkanmod/render/model/CubeModel.java
+++ b/src/main/java/net/vulkanmod/render/model/CubeModel.java
@@ -1,84 +1,56 @@
 package net.vulkanmod.render.model;
 
-import net.minecraft.client.model.geom.ModelPart;
-import net.minecraft.core.Direction;
+import net.minecraft.client.model.geom.ModelPart.Polygon;
+import java.util.HashSet;
+import java.util.Set;
+import org.joml.Matrix3f;
 import org.joml.Matrix4f;
 import org.joml.Vector3f;
 
 public class CubeModel {
+    private static final float SCALE = 1/16F;
 
-    private final ModelPart.Polygon[] polygons = new ModelPart.Polygon[6];
+    private VertexPair[] vertices = new VertexPair[0];
+    private VertexPair[] normals = new VertexPair[0];
 
-    Vector3f[] vertices;
-    Vector3f[] transformed = new Vector3f[8];
+    private boolean verticesCompiled;
 
-    public void setVertices(int i, int j, float f, float g, float h, float k, float l, float m, float n, float o, float p, boolean bl, float q, float r) {
-
-        float s = f + k;
-        float t = g + l;
-        float u = h + m;
-        f -= n;
-        g -= o;
-        h -= p;
-        s += n;
-        t += o;
-        u += p;
-        if (bl) {
-            float v = s;
-            s = f;
-            f = v;
+    public void compileVertices(Polygon[] polygons) {
+        if (verticesCompiled) {
+            // only do it once:
+            // We also only do this on-demand to account for instances where the vertices are altered/replaced.
+            return;
         }
 
-        this.vertices = new Vector3f[]{
-                new Vector3f(f, g, h),
-                new Vector3f(s, g, h),
-                new Vector3f(s, t, h),
-                new Vector3f(f, t, h),
-                new Vector3f(f, g, u),
-                new Vector3f(s, g, u),
-                new Vector3f(s, t, u),
-                new Vector3f(f, t, u)
-        };
+        // dedupe the vertices
+        final Set<Vector3f> vertices = new HashSet<>();
 
-        for (int i1 = 0; i1 < 8; i1++) {
-            //pre-divide all vertices once
-            this.vertices[i1].div(16.0f);
-            this.transformed[i1] = new Vector3f(0.0f);
-//            this.tv[i1] = new Vector3f(this.vertices[i1]);
+        // note some custom cube implementations may have multiple faces with the same normal
+        // so we treat them like vertices dedupe them all the same
+        final Set<Vector3f> normals = new HashSet<>();
+
+        for (Polygon polygon : polygons) {
+            for (int i = 0; i < polygon.vertices.length; i++) {
+                vertices.add(polygon.vertices[i].pos);
+                normals.add(polygon.normal);
+            }
         }
 
-        ModelPart.Vertex vertex1 = new ModelPart.Vertex(transformed[0], 0.0F, 0.0F);
-        ModelPart.Vertex vertex2 = new ModelPart.Vertex(transformed[1], 0.0F, 8.0F);
-        ModelPart.Vertex vertex3 = new ModelPart.Vertex(transformed[2], 8.0F, 8.0F);
-        ModelPart.Vertex vertex4 = new ModelPart.Vertex(transformed[3], 8.0F, 0.0F);
-        ModelPart.Vertex vertex5 = new ModelPart.Vertex(transformed[4], 0.0F, 0.0F);
-        ModelPart.Vertex vertex6 = new ModelPart.Vertex(transformed[5], 0.0F, 8.0F);
-        ModelPart.Vertex vertex7 = new ModelPart.Vertex(transformed[6], 8.0F, 8.0F);
-        ModelPart.Vertex vertex8 = new ModelPart.Vertex(transformed[7], 8.0F, 0.0F);
-
-        float w = (float)i;
-        float x = (float)i + m;
-        float y = (float)i + m + k;
-        float z = (float)i + m + k + k;
-        float aa = (float)i + m + k + m;
-        float ab = (float)i + m + k + m + k;
-        float ac = (float)j;
-        float ad = (float)j + m;
-        float ae = (float)j + m + l;
-        this.polygons[2] = new ModelPart.Polygon(new ModelPart.Vertex[]{vertex6, vertex5, vertex1, vertex2}, x, ac, y, ad, q, r, bl, Direction.DOWN);
-        this.polygons[3] = new ModelPart.Polygon(new ModelPart.Vertex[]{vertex3, vertex4, vertex8, vertex7}, y, ad, z, ac, q, r, bl, Direction.UP);
-        this.polygons[1] = new ModelPart.Polygon(new ModelPart.Vertex[]{vertex1, vertex5, vertex8, vertex4}, w, ad, x, ae, q, r, bl, Direction.WEST);
-        this.polygons[4] = new ModelPart.Polygon(new ModelPart.Vertex[]{vertex2, vertex1, vertex4, vertex3}, x, ad, y, ae, q, r, bl, Direction.NORTH);
-        this.polygons[0] = new ModelPart.Polygon(new ModelPart.Vertex[]{vertex6, vertex2, vertex3, vertex7}, y, ad, aa, ae, q, r, bl, Direction.EAST);
-        this.polygons[5] = new ModelPart.Polygon(new ModelPart.Vertex[]{vertex5, vertex6, vertex7, vertex8}, aa, ad, ab, ae, q, r, bl, Direction.SOUTH);
+        // mul(1/16) as multiplication is faster, instruction-wise than division
+        this.vertices = vertices.stream().map(vertex -> new VertexPair(new Vector3f(vertex.mul(SCALE)), vertex)).toArray(VertexPair[]::new);
+        this.normals = normals.stream().map(normal -> new VertexPair(new Vector3f(normal), normal)).toArray(VertexPair[]::new);
+        verticesCompiled = true;
     }
 
-    public void transformVertices(Matrix4f matrix) {
+    public void transformVertices(Matrix4f positionMatrix, Matrix3f normalMatrix) {
         //Transform original vertices and store them
-        for(int i = 0; i < 8; ++i) {
-            this.vertices[i].mulPosition(matrix, this.transformed[i]);
+        for (VertexPair vertex : vertices) {
+            vertex.original().mulPosition(positionMatrix, vertex.transformed());
+        }
+        for (VertexPair normal : normals) {
+            normalMatrix.transform(normal.original(), normal.transformed());
         }
     }
 
-    public ModelPart.Polygon[] getPolygons() { return this.polygons; }
+    record VertexPair(Vector3f original, Vector3f transformed) {}
 }


### PR DESCRIPTION
Refiling of #284 (rebased to the new branch)

…at use custom cubes.

Also extends the feature to include normals, because why not? (note some cube implementations may have multiple faces with the same normal

The main approach I took was instead of creating a parallel set of vertices, I've rewritten it to instead collect the vertices from the vanilla cube right before rendering them. I dedupe them using a set and store them in the CubeModel class (which is now just a container) to avoid having to do the collecting again.

The transformVertices method works exactly like before, just with some changes to bring normal vectors into the fold.

It shouldn't perform any worse than before, though if it does become a factor the method can be rewritten to not use streams with relative ease. Since it's only done once per cube for the lifetime of the game, I don't think that will be neccessary.

This PR fixes compatibility with Mine Little Pony, as well as any other mod which uses Mson, or a similar library like it that attempts to use model containing cubes with customised vertices.
