### PR TITLE
Add Native Wayland Support + MailBox Mode

### DIFF
--- a/src/main/java/net/vulkanmod/config/Config.java
+++ b/src/main/java/net/vulkanmod/config/Config.java
@@ -14,7 +14,7 @@ public class Config {
 
     public int frameQueueSize = 2;
     public VideoResolution resolution = VideoResolution.getFirstAvailable();
-    public boolean useImmediate = !VideoResolution.isWayLand(); //Necessary until tearing-control-unstable-v1 is fully implemented on all GPU Drivers for Wayland
+    public boolean useTearingMode = !VideoResolution.isWayLand(); //Necessary until tearing-control-unstable-v1 is fully implemented on all GPU Drivers for Wayland
     public boolean windowedFullscreen = false;
     public boolean guiOptimizations = false;
     public int advCulling = 2;

--- a/src/main/java/net/vulkanmod/config/Config.java
+++ b/src/main/java/net/vulkanmod/config/Config.java
@@ -14,6 +14,7 @@ public class Config {
 
     public int frameQueueSize = 2;
     public VideoResolution resolution = VideoResolution.getFirstAvailable();
+    public boolean useImmediate = !VideoResolution.isWayLand(); //Necessary until tearing-control-unstable-v1 is fully implemented on all GPU Drivers for Wayland
     public boolean windowedFullscreen = false;
     public boolean guiOptimizations = false;
     public int advCulling = 2;
@@ -27,7 +28,6 @@ public class Config {
             .setPrettyPrinting()
             .excludeFieldsWithModifiers(Modifier.PRIVATE)
             .create();
-    public boolean useImmediate = !VideoResolution.isWayLand();
 
     public static Config load(Path path) {
         Config config;

--- a/src/main/java/net/vulkanmod/config/Config.java
+++ b/src/main/java/net/vulkanmod/config/Config.java
@@ -27,6 +27,7 @@ public class Config {
             .setPrettyPrinting()
             .excludeFieldsWithModifiers(Modifier.PRIVATE)
             .create();
+    public boolean useImmediate = !VideoResolution.isWayLand();
 
     public static Config load(Path path) {
         Config config;

--- a/src/main/java/net/vulkanmod/config/Options.java
+++ b/src/main/java/net/vulkanmod/config/Options.java
@@ -3,13 +3,15 @@ package net.vulkanmod.config;
 import com.mojang.blaze3d.platform.Window;
 import net.minecraft.client.*;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.contents.LiteralContents;
-import net.minecraft.network.chat.contents.TranslatableContents;
 import net.vulkanmod.Initializer;
 import net.vulkanmod.vulkan.Drawer;
 import net.vulkanmod.vulkan.Renderer;
+import net.vulkanmod.vulkan.Vulkan;
 
 public class Options {
+
+    //Fix Glitches+Crashes if Wayland and the Mesa RADV driver are used, and Queue Frames is set above 2 (possible RADV Bug?)
+    private static final boolean limitSwapChain = VideoResolution.isWayLand() && Vulkan.getDeviceInfo().isAMD();
     static net.minecraft.client.Options minecraftOptions = Minecraft.getInstance().options;
     static Config config = Initializer.CONFIG;
     static Window window = Minecraft.getInstance().getWindow();
@@ -51,9 +53,7 @@ public class Options {
                 new SwitchOption("VSync",
                         value -> {
                             minecraftOptions.enableVsync().set(value);
-                            if (Minecraft.getInstance().getWindow() != null) {
-                                Minecraft.getInstance().getWindow().updateVsync(value);
-                            }
+                            Minecraft.getInstance().getWindow().updateVsync(value);
                         },
                         () -> minecraftOptions.enableVsync().get()),
                 new CyclingOption<>("Gui Scale",
@@ -171,7 +171,7 @@ public class Options {
     public static Option<?>[] getOtherOpts() {
         return new Option[] {
                 new RangeOption("Queue Frames", 2,
-                        5, 1,
+                        limitSwapChain ? 2 : 5, 1,
                         value -> {
                             config.frameQueueSize = value;
                             Renderer.scheduleSwapChainUpdate();

--- a/src/main/java/net/vulkanmod/config/Options.java
+++ b/src/main/java/net/vulkanmod/config/Options.java
@@ -52,11 +52,13 @@ public class Options {
                         () -> minecraftOptions.framerateLimit().get()),
                 new SwitchOption("Permit Tearing",
                         value -> {
-                            config.useImmediate = !wayLand && value; //Always Force Immediate Mode to false if Wayland is used (Wayland is 100% guaranteed to support MailBox Mode)
+                            config.useTearingMode = !wayLand && value; //Always Force Immediate Mode to false if Wayland is used (Wayland is 100% guaranteed to support MailBox Mode)
                             Renderer.scheduleSwapChainUpdate();
                         },
-                        () -> config.useImmediate) .setTooltip(Component.nullToEmpty("""
-                        If supported, prevents screen tearing when Vsync is disabled
+                        () -> config.useTearingMode) .setTooltip(Component.nullToEmpty("""
+                        If supported, prevents screen tearing when this is disabled
+                        if VSync is enabled, Relaxed VSync will be used (capped FPS, but allows tearing)
+                        if VSync is disabled, Mailbox will be used (uncapped FPS, but forbids tearing)
                         May not be supported on all Configurations/Systems
                         (Is always force enabled with Wayland on Linux)""")),
                 new SwitchOption("VSync",

--- a/src/main/java/net/vulkanmod/config/VideoResolution.java
+++ b/src/main/java/net/vulkanmod/config/VideoResolution.java
@@ -19,7 +19,8 @@ public class VideoResolution {
     private static final int[] plats = new int[]{
             GLFW_PLATFORM_WIN32,
             GLFW_PLATFORM_WAYLAND,
-            GLFW_PLATFORM_X11};
+            GLFW_PLATFORM_X11,
+            GLFW_PLATFORM_COCOA};
 
     private static final int activePlat = getSupportedPlat();
 
@@ -87,6 +88,7 @@ public class VideoResolution {
             case GLFW_PLATFORM_WIN32 -> "WIN32";
             case GLFW_PLATFORM_WAYLAND -> "WAYLAND";
             case GLFW_PLATFORM_X11 -> "X11";
+            case GLFW_PLATFORM_COCOA -> "macOS";
             default -> throw new IllegalStateException("Unexpected value: " + plat);
         };
     }
@@ -96,6 +98,7 @@ public class VideoResolution {
     public static boolean isWayLand() { return activePlat == GLFW_PLATFORM_WAYLAND; }
     public static boolean isX11() { return activePlat == GLFW_PLATFORM_X11; }
     public static boolean isWindows() { return activePlat == GLFW_PLATFORM_WIN32; }
+    public static boolean isMacOS() { return activePlat == GLFW_PLATFORM_COCOA; }
 
     public static VideoResolution[] getVideoResolutions() {
         return videoResolutions;

--- a/src/main/java/net/vulkanmod/config/VideoResolution.java
+++ b/src/main/java/net/vulkanmod/config/VideoResolution.java
@@ -9,8 +9,19 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static net.vulkanmod.Initializer.LOGGER;
+import static org.lwjgl.glfw.GLFW.*;
+
 public class VideoResolution {
     private static VideoResolution[] videoResolutions;
+
+    //Make sure Wayland is ALWAYS preferred in 100% of cases (and only fallback to X11 if Wayland isn't available)
+    private static final int[] plats = new int[]{
+            GLFW_PLATFORM_WIN32,
+            GLFW_PLATFORM_WAYLAND,
+            GLFW_PLATFORM_X11};
+
+    private static final int activePlat = getSupportedPlat();
 
     int width;
     int height;
@@ -49,12 +60,42 @@ public class VideoResolution {
 
         return arr;
     }
+    //Prioritise Wayland over X11 if xWayland (if correct) is present
 
     public static void init() {
         RenderSystem.assertOnRenderThread();
+        GLFW.glfwInitHint(GLFW_PLATFORM, activePlat);
         GLFW.glfwInit();
         videoResolutions = populateVideoResolutions(GLFW.glfwGetPrimaryMonitor());
     }
+
+    private static int getSupportedPlat() {
+
+        for (int plat : plats) {
+            if(GLFW.glfwPlatformSupported(plat))
+            {
+                LOGGER.info("Selecting Platform: "+getStringFromPlat(plat));
+                return plat;
+            }
+        }
+        throw new RuntimeException("No Supported Platforms Present!");
+    }
+
+    private static String getStringFromPlat(int plat) {
+        return switch (plat)
+        {
+            case GLFW_PLATFORM_WIN32 -> "WIN32";
+            case GLFW_PLATFORM_WAYLAND -> "WAYLAND";
+            case GLFW_PLATFORM_X11 -> "X11";
+            default -> throw new IllegalStateException("Unexpected value: " + plat);
+        };
+    }
+
+    public static int getActivePlat() { return activePlat; }
+    //Allows platform specific checks to be handles (is missing macOS, however that may not be important due to macOS only version))
+    public static boolean isWayLand() { return activePlat == GLFW_PLATFORM_WAYLAND; }
+    public static boolean isX11() { return activePlat == GLFW_PLATFORM_X11; }
+    public static boolean isWindows() { return activePlat == GLFW_PLATFORM_WIN32; }
 
     public static VideoResolution[] getVideoResolutions() {
         return videoResolutions;

--- a/src/main/java/net/vulkanmod/config/VideoResolution.java
+++ b/src/main/java/net/vulkanmod/config/VideoResolution.java
@@ -94,7 +94,8 @@ public class VideoResolution {
     }
 
     public static int getActivePlat() { return activePlat; }
-    //Allows platform specific checks to be handles (is missing macOS, however that may not be important due to macOS only version))
+
+    //Allows platform specific checks to be handled
     public static boolean isWayLand() { return activePlat == GLFW_PLATFORM_WAYLAND; }
     public static boolean isX11() { return activePlat == GLFW_PLATFORM_X11; }
     public static boolean isWindows() { return activePlat == GLFW_PLATFORM_WIN32; }

--- a/src/main/java/net/vulkanmod/mixin/InputConstantsM.java
+++ b/src/main/java/net/vulkanmod/mixin/InputConstantsM.java
@@ -1,0 +1,22 @@
+package net.vulkanmod.mixin;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import net.vulkanmod.config.VideoResolution;
+import org.lwjgl.glfw.*;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(InputConstants.class)
+public class InputConstantsM {
+    /**
+     * @author
+     * @reason
+     */
+    @Overwrite
+    public static void grabOrReleaseMouse(long l, int i, double d, double e) {
+        if (!VideoResolution.isWayLand()) GLFW.glfwSetCursorPos(l, d, e);
+        GLFW.glfwSetInputMode(l, 208897, i);
+    }
+}

--- a/src/main/java/net/vulkanmod/mixin/debug/GlDebugInfoM.java
+++ b/src/main/java/net/vulkanmod/mixin/debug/GlDebugInfoM.java
@@ -14,7 +14,7 @@ public class GlDebugInfoM {
      */
     @Overwrite
     public static String getVendor() {
-        return Vulkan.getDeviceInfo() != null ? Vulkan.getDeviceInfo().vendorId : "n/a";
+        return Vulkan.getDeviceInfo() != null ? Vulkan.getDeviceInfo().vendorIdString : "n/a";
     }
 
     /**

--- a/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
+++ b/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
@@ -28,7 +28,8 @@ public class DeviceInfo {
     public static final List<GraphicsCard> graphicsCards;
 
     private final VkPhysicalDevice device;
-    public final String vendorId;
+    public final int vendorId;
+    public final String vendorIdString;
     public final String deviceName;
     public final String driverVersion;
     public final String vkVersion;
@@ -57,7 +58,8 @@ public class DeviceInfo {
         }
 
         this.device = device;
-        this.vendorId = decodeVendor(properties.vendorID());
+        this.vendorId = properties.vendorID();
+        this.vendorIdString = decodeVendor(this.vendorId);
         this.deviceName = properties.deviceNameString();
         this.driverVersion = decodeDvrVersion(Device.deviceProperties.driverVersion(), Device.deviceProperties.vendorID());
         this.vkVersion = decDefVersion(getVkVer());
@@ -184,5 +186,17 @@ public class DeviceInfo {
 
     public boolean isDrawIndirectSupported() {
         return drawIndirectSupported;
+    }
+
+    //Added these to allow GPU and vendor specific fixes to be applied
+    // (e.g. if we run into a bug that only occurs on a specific GPU, and only on Wayland for example e.g.)
+    public boolean isAMD() {
+        return this.vendorId==0x1022;
+    }
+    public boolean isNvidia() {
+        return this.vendorId==0x10DE;
+    }
+    public boolean isIntel() {
+        return this.vendorId==0x8086;
     }
 }

--- a/src/main/java/net/vulkanmod/vulkan/framebuffer/SwapChain.java
+++ b/src/main/java/net/vulkanmod/vulkan/framebuffer/SwapChain.java
@@ -6,6 +6,7 @@ import net.vulkanmod.vulkan.Device;
 import net.vulkanmod.vulkan.Renderer;
 import net.vulkanmod.vulkan.Synchronization;
 import net.vulkanmod.vulkan.Vulkan;
+import net.vulkanmod.config.VideoResolution;
 import net.vulkanmod.vulkan.queue.Queue;
 import net.vulkanmod.vulkan.texture.VulkanImage;
 import org.lwjgl.system.MemoryStack;
@@ -34,8 +35,9 @@ public class SwapChain extends Framebuffer {
     }
 
     private RenderPass renderPass;
+    //Necessary until tearing-control-unstable-v1 is fully implemented on all GPU Drivers for Wayland
+    private static final int defUncappedMode = VideoResolution.isWayLand() ? VK_PRESENT_MODE_MAILBOX_KHR : VK_PRESENT_MODE_IMMEDIATE_KHR;
     private long[] framebuffers;
-
     private long swapChain = VK_NULL_HANDLE;
     private List<VulkanImage> swapChainImages;
     private VkExtent2D extent2D;
@@ -353,7 +355,7 @@ public class SwapChain extends Framebuffer {
     }
 
     private int getPresentMode(IntBuffer availablePresentModes) {
-        int requestedMode = vsync ? VK_PRESENT_MODE_FIFO_KHR : VK_PRESENT_MODE_IMMEDIATE_KHR;
+        int requestedMode = vsync ? VK_PRESENT_MODE_FIFO_KHR : defUncappedMode;
 
         //fifo mode is the only mode that has to be supported
         if(requestedMode == VK_PRESENT_MODE_FIFO_KHR)

--- a/src/main/java/net/vulkanmod/vulkan/framebuffer/SwapChain.java
+++ b/src/main/java/net/vulkanmod/vulkan/framebuffer/SwapChain.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static net.vulkanmod.Initializer.LOGGER;
 import static net.vulkanmod.vulkan.Vulkan.*;
 import static net.vulkanmod.vulkan.util.VUtil.UINT32_MAX;
 import static org.lwjgl.glfw.GLFW.glfwGetFramebufferSize;
@@ -355,11 +356,16 @@ public class SwapChain extends Framebuffer {
     }
 
     private int getPresentMode(IntBuffer availablePresentModes) {
-        int requestedMode = vsync ? VK_PRESENT_MODE_FIFO_KHR : defUncappedMode;
+
+        int requestedMode = Initializer.CONFIG.useImmediate ? VK_PRESENT_MODE_IMMEDIATE_KHR : VK_PRESENT_MODE_MAILBOX_KHR;
 
         //fifo mode is the only mode that has to be supported
-        if(requestedMode == VK_PRESENT_MODE_FIFO_KHR)
+        if (vsync) {
             return VK_PRESENT_MODE_FIFO_KHR;
+        }
+
+        //Available Display modes in fullscreen and windowed can vary, so we can't optimise out this loop
+        //(e.g. due to a driver bug, Nvidia on Wayland with KWin only supports FIFO in fullscreen, but supports both FIFO and MAILBOX Mode in Windowed
 
         for(int i = 0;i < availablePresentModes.capacity();i++) {
             if(availablePresentModes.get(i) == requestedMode) {

--- a/src/main/resources/vulkanmod.mixins.json
+++ b/src/main/resources/vulkanmod.mixins.json
@@ -7,16 +7,16 @@
   "mixins": [
   ],
   "client": [
+    "InputConstantsM",
+    "WindowMixin",
     "chunk.DirectionMixin",
     "chunk.FrustumMixin",
     "chunk.LevelRendererMixin",
     "chunk.VisibilitySetMixin",
-
-    "compatibility.gl.GL11M",
     "compatibility.EffectInstanceM",
     "compatibility.ProgramM",
     "compatibility.UniformM",
-
+    "compatibility.gl.GL11M",
     "debug.ChunkBorderRendererM",
     "debug.GlDebugInfoM",
     "debug.KeyboardHandlerM",
@@ -25,9 +25,7 @@
     "gui.ChatComponentM",
     "gui.DebugHudM",
     "gui.GuiM",
-
     "matrix.Matrix4fM",
-
     "profiling.GuiMixin",
     "profiling.KeyboardHandlerM",
 
@@ -41,39 +39,41 @@
     "render.vertex.LiquidBlockRendererM",
     "render.vertex.VertexFormatMixin",
     "render.BufferUploaderM",
-    "render.RenderTargetMixin",
     "render.GameRendererMixin",
     "render.GlProgramManagerMixin",
     "render.GlStateManagerM",
-    "render.vertex.IndexTypeMixin",
+    "render.LevelRendererMixin",
+    "render.MainTargetMixin",
     "render.MinecraftMixin",
     "render.RenderSystemMixin",
+    "render.RenderTargetMixin",
     "render.ShaderInstanceM",
-    "render.MainTargetMixin",
-    "render.LevelRendererMixin",
-
+    "render.model.ModelPartCubeM",
+    "render.model.ModelPartM",
+    "render.vertex.BufferBuilderM",
+    "render.vertex.FaceBakeryM",
+    "render.vertex.IndexTypeMixin",
+    "render.vertex.LiquidBlockRendererM",
+    "render.vertex.VertexBufferM",
+    "render.vertex.VertexConsumerM",
+    "render.vertex.VertexFormatMixin",
     "screen.OptionsScreenM",
-
     "texture.MAbstractTexture",
     "texture.MDynamicTexture",
     "texture.MFontTexture",
     "texture.MLightTexture",
+    "texture.MNativeImage",
     "texture.MOverlayTexture",
     "texture.MPlayerSkinTexture",
     "texture.MSimpleTexture",
     "texture.MSpriteAtlasTexture",
     "texture.MSpriteContents",
     "texture.MTextureManager",
-    "texture.MNativeImage",
-
     "util.ScreenshotRecorderM",
-
     "vertex.SpriteCoordinateExpanderM",
     "vertex.VertexMultiConsumersM$DoubleM",
     "vertex.VertexMultiConsumersM$MultipleM",
-    "vertex.VertexMultiConsumersM$SheetDecalM",
-
-    "WindowMixin"
+    "vertex.VertexMultiConsumersM$SheetDecalM"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Rebase of https://github.com/xCollateral/VulkanMod/pull/291 onto the new 1.20.x default branch

This is mostly identical to the prior PR, outside of expanding Mailbox mode to be usable on all platforms, not just Wayland
(if the GPU driver supports MailBox Mode)

As before this won't include support for tearing-control-unstable-v1, (can't figure out how to enable/use it properly)
so Mailbox instead of Immediate mode will be used as the default display mode when Vsync is disabled

This also will not use swapchain images above 2 if Wayland + AMD is detected to avoid game breaking glitches
~~(Due to a suspected RADV driver bug)~~ 
(This was actually due to a limitation with the current Swapchain system used in the mod, 
this has been fixed and will be added when the new version of this PR is opened)