### PR TITLE
Add Experimental GPU Selector

### DIFF
--- a/src/main/java/net/vulkanmod/config/Config.java
+++ b/src/main/java/net/vulkanmod/config/Config.java
@@ -20,6 +20,7 @@ public class Config {
     public boolean indirectDraw = false;
     public boolean uniqueOpaqueLayer = true;
     public boolean entityCulling = true;
+    public int selectedGPU=-1;
 
     private static Path path;
 

--- a/src/main/java/net/vulkanmod/config/Options.java
+++ b/src/main/java/net/vulkanmod/config/Options.java
@@ -4,17 +4,25 @@ import com.mojang.blaze3d.platform.Window;
 import net.minecraft.client.*;
 import net.minecraft.network.chat.Component;
 import net.vulkanmod.Initializer;
+
 import net.vulkanmod.vulkan.Device;
 import net.vulkanmod.vulkan.Renderer;
 import org.lwjgl.system.MemoryStack;
 
-import static net.vulkanmod.vulkan.Device.device;
+
+import net.vulkanmod.vulkan.Vulkan;
+
+import java.util.stream.IntStream;
+
 
 public class Options {
     static net.minecraft.client.Options minecraftOptions = Minecraft.getInstance().options;
     static Config config = Initializer.CONFIG;
     static Window window = Minecraft.getInstance().getWindow();
     public static boolean fullscreenDirty = false;
+
+
+    private static final String[] GPUNames = Vulkan.getAvailableGPUs();
 
     public static Option<?>[] getVideoOpts() {
         return new Option[] {
@@ -212,7 +220,15 @@ public class Options {
                         () -> config.indirectDraw)
                         .setTooltip(Component.nullToEmpty("""
                         Reduces CPU overhead but increases GPU overhead.
-                        Enabling it might help in CPU limited systems."""))
+                        Enabling it might help in CPU limited systems.""")),
+                new RangeOption("GPU Selector", 0, GPUNames.length-1, 1,
+
+                        value -> GPUNames[value],
+
+                        value -> config.selectedGPU = value,
+                        () -> config.selectedGPU)
+                        .setTooltip(Component.nullToEmpty("""
+                        GPU Selector""")),
         };
 
     }

--- a/src/main/java/net/vulkanmod/config/Options.java
+++ b/src/main/java/net/vulkanmod/config/Options.java
@@ -221,9 +221,9 @@ public class Options {
                         .setTooltip(Component.nullToEmpty("""
                         Reduces CPU overhead but increases GPU overhead.
                         Enabling it might help in CPU limited systems.""")),
-                new RangeOption("GPU Selector", 0, GPUNames.length-1, 1,
+                new RangeOption("GPU Selector", -1, GPUNames.length-1, 1,
 
-                        value -> GPUNames[value],
+                        value -> (value!=-1 ? GPUNames[value] : "Unselected"),
 
                         value -> config.selectedGPU = value,
                         () -> config.selectedGPU)

--- a/src/main/java/net/vulkanmod/vulkan/Device.java
+++ b/src/main/java/net/vulkanmod/vulkan/Device.java
@@ -55,7 +55,7 @@ public class Device {
             final int selectedGPU = Math.min(Initializer.CONFIG.selectedGPU, ppPhysicalDevices.length-1);
             if(selectedGPU !=-1) {
                 GPUCandidate ppPhysicalDevice = ppPhysicalDevices[selectedGPU];
-                currentDevice = isDeviceSuitable(ppPhysicalDevice) ? ppPhysicalDevice : null;
+                currentDevice = isDeviceSuitable(ppPhysicalDevice) ? ppPhysicalDevice : enumerateGPUCandidates(ppPhysicalDevices);
             }
             else currentDevice = enumerateGPUCandidates(ppPhysicalDevices);
 

--- a/src/main/java/net/vulkanmod/vulkan/Device.java
+++ b/src/main/java/net/vulkanmod/vulkan/Device.java
@@ -46,37 +46,24 @@ public class Device {
         try(MemoryStack stack = stackPush()) {
 
 
-            GPUCandidate[] ppPhysicalDevices = getAvailableGPUs(instance, stack);
-
+            final GPUCandidate[] ppPhysicalDevices = getAvailableGPUs(instance, stack);
 
 
             final GPUCandidate currentDevice;
 
 
             final int selectedGPU = Math.min(Initializer.CONFIG.selectedGPU, ppPhysicalDevices.length-1);
-            if(selectedGPU !=-1)
-            {
-                currentDevice = ppPhysicalDevices[selectedGPU];
-                Initializer.LOGGER.info("User Selection Detected" + selectedGPU);
-                Initializer.LOGGER.info("Using Selected GPU Device: "+currentDevice.deviceName());
-                Initializer.LOGGER.info("Skipping Suitability Checks");
-                if(!isDeviceSuitable(currentDevice))
-                {
-                    Initializer.LOGGER.error(DeviceInfo.debugString(ppPhysicalDevices, Vulkan.REQUIRED_EXTENSION));
-                    throw new RuntimeException("Failed to find a suitable GPU");
-
-                }
+            if(selectedGPU !=-1) {
+                GPUCandidate ppPhysicalDevice = ppPhysicalDevices[selectedGPU];
+                currentDevice = isDeviceSuitable(ppPhysicalDevice) ? ppPhysicalDevice : null;
             }
-            else{
+            else currentDevice = enumerateGPUCandidates(ppPhysicalDevices);
 
 
-                Initializer.LOGGER.info(ppPhysicalDevices.length + " Devices Detected");
-                currentDevice = enumerateGPUCandidates(ppPhysicalDevices);
-
-                if(currentDevice==null) {
-                    Initializer.LOGGER.error(DeviceInfo.debugString(ppPhysicalDevices, Vulkan.REQUIRED_EXTENSION));
-                    throw new RuntimeException("Failed to find a suitable GPU");
-                }
+            if(currentDevice==null)
+            {
+                Initializer.LOGGER.error(DeviceInfo.debugString(ppPhysicalDevices, Vulkan.REQUIRED_EXTENSION));
+                throw new RuntimeException("Failed to find a suitable GPU");
             }
 
 
@@ -97,34 +84,9 @@ public class Device {
         }
     }
 
-
-    @Nullable
-    private static GPUCandidate getGPUMatchingName(GPUCandidate[] ppPhysicalDevices, String selectedGPU) {
-        for (GPUCandidate gpuCandidate1 : ppPhysicalDevices) {
-            if (Objects.equals(gpuCandidate1.deviceName(), selectedGPU)) {
-                return gpuCandidate1;
-            }
-        }
-        return null;
-    }
-
-    private static GPUCandidate getGPUForName(GPUCandidate[] ppPhysicalDevices, String selectedGPU) {
-        for (var a : ppPhysicalDevices)
-        {
-            if(a.deviceName().equals(selectedGPU))
-            {
-                return a;
-            }
-
-
-
-        }
-        return null;
-    }
-
     private static GPUCandidate enumerateGPUCandidates(GPUCandidate... ppPhysicalDevices) {
 
-
+        Initializer.LOGGER.info(ppPhysicalDevices.length + " Devices Detected");
 
         ArrayList<GPUCandidate> dGPUs = new ArrayList<>();
         ArrayList<GPUCandidate> iGPUs = new ArrayList<>();

--- a/src/main/java/net/vulkanmod/vulkan/Device.java
+++ b/src/main/java/net/vulkanmod/vulkan/Device.java
@@ -77,7 +77,6 @@ public class Device {
                     Initializer.LOGGER.error(DeviceInfo.debugString(ppPhysicalDevices, Vulkan.REQUIRED_EXTENSION));
                     throw new RuntimeException("Failed to find a suitable GPU");
                 }
-                Initializer.CONFIG.selectedGPU=currentDevice.i();
             }
 
 

--- a/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
+++ b/src/main/java/net/vulkanmod/vulkan/DeviceInfo.java
@@ -159,13 +159,13 @@ public class DeviceInfo {
         }
     }
 
-    public static String debugString(PointerBuffer ppPhysicalDevices, Set<String> requiredExtensions, VkInstance instance) {
+    public static String debugString(GPUCandidate[] ppPhysicalDevices, Set<String> requiredExtensions) {
         try (MemoryStack stack = stackPush()) {
             StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.append("\n");
 
-            for(int i = 0; i < ppPhysicalDevices.capacity();i++) {
-                VkPhysicalDevice device = new VkPhysicalDevice(ppPhysicalDevices.get(i), instance);
+            for(int i = 0; i < ppPhysicalDevices.length;i++) {
+                VkPhysicalDevice device = ppPhysicalDevices[i].physicalDevice();
 
                 VkPhysicalDeviceProperties deviceProperties = VkPhysicalDeviceProperties.callocStack(stack);
                 vkGetPhysicalDeviceProperties(device, deviceProperties);

--- a/src/main/java/net/vulkanmod/vulkan/GPUCandidate.java
+++ b/src/main/java/net/vulkanmod/vulkan/GPUCandidate.java
@@ -1,0 +1,18 @@
+package net.vulkanmod.vulkan;
+
+import org.lwjgl.vulkan.VkPhysicalDevice;
+
+import static org.lwjgl.vulkan.VK10.*;
+
+public record GPUCandidate(VkPhysicalDevice physicalDevice, String deviceName, int deviceType, int i) {
+    String getDeviceTypeString() {
+        return switch (this.deviceType) {
+            case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU -> "DISCRETE_GPU";
+            case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU -> "INTEGRATED_GPU";
+            case VK_PHYSICAL_DEVICE_TYPE_OTHER -> "OTHER";
+            case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU -> "VIRTUAL_GPU";
+            case VK_PHYSICAL_DEVICE_TYPE_CPU -> "CPU";
+            default -> "UNKNOWN";
+        };
+    }
+}

--- a/src/main/java/net/vulkanmod/vulkan/Vulkan.java
+++ b/src/main/java/net/vulkanmod/vulkan/Vulkan.java
@@ -9,7 +9,6 @@ import net.vulkanmod.vulkan.queue.GraphicsQueue;
 import net.vulkanmod.vulkan.queue.Queue;
 import net.vulkanmod.vulkan.queue.TransferQueue;
 import net.vulkanmod.vulkan.shader.Pipeline;
-import net.vulkanmod.vulkan.texture.VTextureSelector;
 import net.vulkanmod.vulkan.texture.VulkanImage;
 import net.vulkanmod.vulkan.util.VUtil;
 import org.lwjgl.PointerBuffer;
@@ -461,5 +460,11 @@ public class Vulkan {
     public static StagingBuffer getStagingBuffer() { return stagingBuffers[Renderer.getCurrentFrame()]; }
 
     public static DeviceInfo getDeviceInfo() { return Device.deviceInfo; }
+
+    public static String[] getAvailableGPUs() {
+        try(MemoryStack stack = stackPush()) {
+            return Device.getAvailableGPUNames(instance, stack);
+        }
+    }
 }
 

--- a/src/main/java/net/vulkanmod/vulkan/framebuffer/SwapChain.java
+++ b/src/main/java/net/vulkanmod/vulkan/framebuffer/SwapChain.java
@@ -124,7 +124,7 @@ public class SwapChain extends Framebuffer {
 
             Queue.QueueFamilyIndices indices = Queue.getQueueFamilies();
 
-            if(!indices.graphicsFamily.equals(indices.presentFamily)) {
+            if(indices.graphicsFamily == indices.presentFamily) {
                 createInfo.imageSharingMode(VK_SHARING_MODE_CONCURRENT);
                 createInfo.pQueueFamilyIndices(stack.ints(indices.graphicsFamily, indices.presentFamily));
             } else {

--- a/src/main/java/net/vulkanmod/vulkan/queue/Queue.java
+++ b/src/main/java/net/vulkanmod/vulkan/queue/Queue.java
@@ -105,7 +105,7 @@ public abstract class Queue {
                     indices.transferFamily = i;
                 }
 
-                if(indices.presentFamily == null) {
+                if(indices.presentFamily == VK_QUEUE_FAMILY_IGNORED) {
                     vkGetPhysicalDeviceSurfaceSupportKHR(device, i, Vulkan.getSurface(), presentSupport);
 
                     if(presentSupport.get(0) == VK_TRUE) {
@@ -116,7 +116,7 @@ public abstract class Queue {
                 if(indices.isComplete()) break;
             }
 
-            if(indices.transferFamily == null) {
+            if(indices.transferFamily == VK_QUEUE_FAMILY_IGNORED) {
 
                 int fallback = -1;
                 for(int i = 0; i < queueFamilies.capacity(); i++) {
@@ -142,7 +142,7 @@ public abstract class Queue {
                 }
             }
             
-            if(indices.computeFamily == null) {
+            if(indices.computeFamily == VK_QUEUE_FAMILY_IGNORED) {
                 for(int i = 0; i < queueFamilies.capacity(); i++) {
                     int queueFlags = queueFamilies.get(i).queueFlags();
 
@@ -153,11 +153,11 @@ public abstract class Queue {
                 }
             }
 
-            if (indices.graphicsFamily == null)
+            if (indices.graphicsFamily == VK_QUEUE_FAMILY_IGNORED)
                 throw new RuntimeException("Unable to find queue family with graphics support.");
-            if (indices.presentFamily == null)
+            if (indices.presentFamily == VK_QUEUE_FAMILY_IGNORED)
                 throw new RuntimeException("Unable to find queue family with present support.");
-            if (indices.computeFamily == null)
+            if (indices.computeFamily == VK_QUEUE_FAMILY_IGNORED)
                 throw new RuntimeException("Unable to find queue family with compute support.");
 
             return indices;
@@ -165,19 +165,14 @@ public abstract class Queue {
     }
 
     public static class QueueFamilyIndices {
-
-        // We use Integer to use null as the empty value
-        public Integer graphicsFamily;
-        public Integer presentFamily;
-        public Integer transferFamily;
-        public Integer computeFamily;
+        public int graphicsFamily, presentFamily, transferFamily, computeFamily;
 
         public boolean isComplete() {
-            return graphicsFamily != null && presentFamily != null && transferFamily != null && computeFamily != null;
+            return graphicsFamily != VK_QUEUE_FAMILY_IGNORED && presentFamily != VK_QUEUE_FAMILY_IGNORED && transferFamily != VK_QUEUE_FAMILY_IGNORED && computeFamily != VK_QUEUE_FAMILY_IGNORED;
         }
 
         public boolean isSuitable() {
-            return graphicsFamily != null && presentFamily != null;
+            return graphicsFamily != VK_QUEUE_FAMILY_IGNORED && presentFamily != VK_QUEUE_FAMILY_IGNORED;
         }
 
         public int[] unique() {


### PR DESCRIPTION
This is a quick PR to fix an issue with some multi-GPU users, where they are unable to select their preferred GPU due to GPU ordering priority

This adds the ability to switch between auto mode, which is the current system, and a preferred GPU override.
So under default conditions the Initialisation process is mostly unchanged

This PR also adds some non critical functionality such more detailed Log output, including the GPU being selected, and  GPU error/failure reasons.
