### PR TITLE
Add support for asdf

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+java openjdk-17.0.2
+gradle 8.5


### PR DESCRIPTION
Add `.tool-versions` file to support asdf to install the correct version of java and gradle. With this users only need to run:

* asdf plugin add java
* asdf plugin add gradle
* asdf install
* gradle build

Helps a lot when someone needs to do a quick build.