### PR TITLE
Add Xwayland config override + Gnome window border workarounds

### DIFF
--- a/src/main/java/net/vulkanmod/Initializer.java
+++ b/src/main/java/net/vulkanmod/Initializer.java
@@ -26,7 +26,6 @@ public class Initializer implements ClientModInitializer {
 
 		LOGGER.info("== VulkanMod ==");
 
-		VideoResolution.init();
 
 		var configPath = FabricLoader.getInstance()
 				.getConfigDir()
@@ -34,14 +33,15 @@ public class Initializer implements ClientModInitializer {
 
 		CONFIG = loadConfig(configPath);
 
+		VideoResolution.init();
 	}
 
 	private static Config loadConfig(Path path) {
 		Config config = Config.load(path);
 		if(config == null) {
 			config = new Config();
-			config.write();
 		}
+		config.write();
 		return config;
 	}
 

--- a/src/main/java/net/vulkanmod/config/Config.java
+++ b/src/main/java/net/vulkanmod/config/Config.java
@@ -14,6 +14,7 @@ public class Config {
 
     public int frameQueueSize = 2;
     public VideoResolution resolution = VideoResolution.getFirstAvailable();
+    public boolean xWayland = false;
     public boolean windowedFullscreen = false;
     public boolean guiOptimizations = false;
     public int advCulling = 2;

--- a/src/main/java/net/vulkanmod/config/VideoResolution.java
+++ b/src/main/java/net/vulkanmod/config/VideoResolution.java
@@ -62,7 +62,7 @@ public class VideoResolution {
         boolean useXwaylandOverride = Initializer.CONFIG.xWayland && isWayLand();
         int overriddenPlat = useXwaylandOverride ? GLFW_PLATFORM_X11 : activePlat;
         GLFW.glfwInitHint(GLFW_PLATFORM, overriddenPlat);
-        LOGGER.info("Selecting Platform: " + getStringFromPlat(overriddenPlat) + (useXwaylandOverride ? "(Xwayland Override)" : null));
+        LOGGER.info("Selecting Platform: " + (useXwaylandOverride ? getStringFromPlat(overriddenPlat) + " (Xwayland Override)" : getStringFromPlat(overriddenPlat) ));
         LOGGER.info("GLFW: "+GLFW.glfwGetVersionString());
         GLFW.glfwInit();
         videoResolutions = populateVideoResolutions(GLFW.glfwGetPrimaryMonitor());
@@ -119,7 +119,7 @@ public class VideoResolution {
     public static boolean isAndroid() { return activePlat == GLFW_ANY_PLATFORM; }
 
     //Desktop Environment Names: https://wiki.archlinux.org/title/Environment_variables_#Examples
-    public static boolean isGNOME(){return activeDE.equals("GNOME")||activeDE.equals("GNOME_Flashback");}
+    public static boolean isGNOME(){return activeDE.contains("GNOME");}
 
 
 

--- a/src/main/java/net/vulkanmod/config/VideoResolution.java
+++ b/src/main/java/net/vulkanmod/config/VideoResolution.java
@@ -119,7 +119,8 @@ public class VideoResolution {
     public static boolean isAndroid() { return activePlat == GLFW_ANY_PLATFORM; }
 
     //Desktop Environment Names: https://wiki.archlinux.org/title/Environment_variables_#Examples
-    public static boolean isGNOME(){return activeDE.contains("gnome") || activeDE.contains("GNOME");}
+    public static boolean isGnome(){return activeDE.contains("gnome");}
+    public static boolean isKWin(){return activeDE.contains("kde");}
 
 
 

--- a/src/main/java/net/vulkanmod/config/VideoResolution.java
+++ b/src/main/java/net/vulkanmod/config/VideoResolution.java
@@ -84,7 +84,7 @@ public class VideoResolution {
 
     private static String determineDE() {
         String xdgSessionDesktop = System.getenv("XDG_SESSION_DESKTOP");
-        return xdgSessionDesktop != null ? xdgSessionDesktop : "N/A";
+        return (xdgSessionDesktop != null ? xdgSessionDesktop : "N/A").toLowerCase();
     }
 
 
@@ -119,7 +119,7 @@ public class VideoResolution {
     public static boolean isAndroid() { return activePlat == GLFW_ANY_PLATFORM; }
 
     //Desktop Environment Names: https://wiki.archlinux.org/title/Environment_variables_#Examples
-    public static boolean isGNOME(){return activeDE.contains("GNOME");}
+    public static boolean isGNOME(){return activeDE.contains("gnome") || activeDE.contains("GNOME");}
 
 
 

--- a/src/main/java/net/vulkanmod/config/VideoResolution.java
+++ b/src/main/java/net/vulkanmod/config/VideoResolution.java
@@ -2,6 +2,7 @@ package net.vulkanmod.config;
 
 import com.mojang.blaze3d.platform.VideoMode;
 import com.mojang.blaze3d.systems.RenderSystem;
+import net.vulkanmod.Initializer;
 import org.apache.commons.lang3.SystemUtils;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWVidMode;
@@ -16,12 +17,13 @@ import static org.lwjgl.glfw.GLFW.*;
 public class VideoResolution {
     private static VideoResolution[] videoResolutions;
     private static final int activePlat = getSupportedPlat();
+    private static final String activeDE=determineDE();
 
     int width;
     int height;
     int refreshRate;
 
-    private List<VideoMode> videoModes;
+    private final List<VideoMode> videoModes;
 
     public VideoResolution(int width, int height) {
         this.width = width;
@@ -57,8 +59,10 @@ public class VideoResolution {
 
     public static void init() {
         RenderSystem.assertOnRenderThread();
-        GLFW.glfwInitHint(GLFW_PLATFORM, activePlat);
-        LOGGER.info("Selecting Platform: "+getStringFromPlat(activePlat));
+        boolean useXwaylandOverride = Initializer.CONFIG.xWayland && isWayLand();
+        int overriddenPlat = useXwaylandOverride ? GLFW_PLATFORM_X11 : activePlat;
+        GLFW.glfwInitHint(GLFW_PLATFORM, overriddenPlat);
+        LOGGER.info("Selecting Platform: " + getStringFromPlat(overriddenPlat) + (useXwaylandOverride ? "(Xwayland Override)" : null));
         LOGGER.info("GLFW: "+GLFW.glfwGetVersionString());
         GLFW.glfwInit();
         videoResolutions = populateVideoResolutions(GLFW.glfwGetPrimaryMonitor());
@@ -76,6 +80,13 @@ public class VideoResolution {
             default -> GLFW_ANY_PLATFORM; //Either unknown Platform or Display Server
         };
     }
+
+
+    private static String determineDE() {
+        String xdgSessionDesktop = System.getenv("XDG_SESSION_DESKTOP");
+        return xdgSessionDesktop != null ? xdgSessionDesktop : "N/A";
+    }
+
 
     private static int getSupportedPlat() {
         //Switch statement would be ideal, but couldn't find a good way of implementing it, so fell back to basic if statements/branches
@@ -106,6 +117,11 @@ public class VideoResolution {
     public static boolean isWindows() { return activePlat == GLFW_PLATFORM_WIN32; }
     public static boolean isMacOS() { return activePlat == GLFW_PLATFORM_COCOA; }
     public static boolean isAndroid() { return activePlat == GLFW_ANY_PLATFORM; }
+
+    //Desktop Environment Names: https://wiki.archlinux.org/title/Environment_variables_#Examples
+    public static boolean isGNOME(){return activeDE.equals("GNOME")||activeDE.equals("GNOME_Flashback");}
+
+
 
     public static VideoResolution[] getVideoResolutions() {
         return videoResolutions;

--- a/src/main/java/net/vulkanmod/mixin/wayland/MinecraftMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/wayland/MinecraftMixin.java
@@ -30,7 +30,7 @@ public class MinecraftMixin {
      */
     @Redirect(method="<init>", at=@At(value="INVOKE", target="Lcom/mojang/blaze3d/platform/Window;setIcon(Lnet/minecraft/server/packs/PackResources;Lcom/mojang/blaze3d/platform/IconSet;)V"))
     private void bypassWaylandIcon(Window instance, PackResources packResources, IconSet iconSet) throws IOException {
-        if(!VideoResolution.isWayLand())
+        if(VideoResolution.isKWin() || !VideoResolution.isWayLand())
         {
             this.window.setIcon(this.vanillaPackResources, SharedConstants.getCurrentVersion().isStable() ? IconSet.RELEASE : IconSet.SNAPSHOT);
         }

--- a/src/main/java/net/vulkanmod/mixin/window/WindowMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/window/WindowMixin.java
@@ -17,7 +17,6 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -70,6 +69,8 @@ public abstract class WindowMixin {
     @Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lorg/lwjgl/glfw/GLFW;glfwCreateWindow(IILjava/lang/CharSequence;JJ)J"))
     private void vulkanHint(WindowEventHandler windowEventHandler, ScreenManager screenManager, DisplayData displayData, String string, String string2, CallbackInfo ci) {
         GLFW.glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+        //Fix Gnome Client-Side Decorators
+        GLFW.glfwWindowHint(GLFW_DECORATED, VideoResolution.isGNOME() && VideoResolution.isWayLand() ? GLFW_FALSE : GLFW_TRUE);
 //        GLFW.glfwWindowHint(GLFW_AUTO_ICONIFY, GLFW_FALSE);
 //        GLFW.glfwWindowHint(GLFW_FOCUSED, GLFW_FALSE);
     }

--- a/src/main/java/net/vulkanmod/mixin/window/WindowMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/window/WindowMixin.java
@@ -70,7 +70,7 @@ public abstract class WindowMixin {
     private void vulkanHint(WindowEventHandler windowEventHandler, ScreenManager screenManager, DisplayData displayData, String string, String string2, CallbackInfo ci) {
         GLFW.glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
         //Fix Gnome Client-Side Decorators
-        GLFW.glfwWindowHint(GLFW_DECORATED, VideoResolution.isGNOME() && VideoResolution.isWayLand() ? GLFW_FALSE : GLFW_TRUE);
+        GLFW.glfwWindowHint(GLFW_DECORATED, VideoResolution.isGnome() && VideoResolution.isWayLand() ? GLFW_FALSE : GLFW_TRUE);
 //        GLFW.glfwWindowHint(GLFW_AUTO_ICONIFY, GLFW_FALSE);
 //        GLFW.glfwWindowHint(GLFW_FOCUSED, GLFW_FALSE);
     }


### PR DESCRIPTION
Adds an optional Xwayland override that can be changed from the config file, which is applied when restarting the client. This isn't exposed in options menu though to avoid clutter

This is mostly intended for Wayland-specific issues that can't be fixed by the mod itself 
_(e.g. Broken window scaling due to glfw lacking support for wp_fractional_scale_v1 , Gnome missing window decorators)_

_(Also includes a gnome-related workaround in an attempt to fix: https://github.com/xCollateral/VulkanMod/issues/336)_