### PR TITLE
Add Post Effect Detection + Attachment Clear Color Skips

### DIFF
--- a/src/main/java/net/vulkanmod/mixin/chunk/LevelRendererMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/chunk/LevelRendererMixin.java
@@ -50,12 +50,13 @@ public abstract class LevelRendererMixin {
     @Shadow private boolean generateClouds;
     @Shadow @Final private EntityRenderDispatcher entityRenderDispatcher;
 
-    @Shadow protected abstract boolean shouldShowEntityOutlines();
+
 
     @Shadow public abstract void needsUpdate();
 
     @Shadow public abstract void renderLevel(PoseStack poseStack, float f, long l, boolean bl, Camera camera, GameRenderer gameRenderer, LightTexture lightTexture, Matrix4f matrix4f);
 
+    @Unique
     private WorldRenderer worldRenderer;
 
     @Unique
@@ -80,6 +81,15 @@ public abstract class LevelRendererMixin {
     private void renderBlockEntities(PoseStack poseStack, float f, long l, boolean bl, Camera camera, GameRenderer gameRenderer, LightTexture lightTexture, Matrix4f matrix4f, CallbackInfo ci) {
         Vec3 pos = camera.getPosition();
         this.worldRenderer.renderBlockEntities(poseStack, pos.x(), pos.y(), pos.z(), this.destructionProgress, f);
+    }
+
+    /**
+     * @author
+     * @reason
+     */
+    @Overwrite
+    public boolean shouldShowEntityOutlines() {
+        return false; //Temp Fix: Disable Glowing due to flickering artifacts with Post effect detection
     }
 
     /**

--- a/src/main/java/net/vulkanmod/mixin/texture/image/MNativeImage.java
+++ b/src/main/java/net/vulkanmod/mixin/texture/image/MNativeImage.java
@@ -2,6 +2,7 @@ package net.vulkanmod.mixin.texture.image;
 
 import com.mojang.blaze3d.platform.NativeImage;
 import com.mojang.blaze3d.systems.RenderSystem;
+import net.vulkanmod.vulkan.Renderer;
 import net.vulkanmod.vulkan.Vulkan;
 import net.vulkanmod.vulkan.texture.ImageUtil;
 import net.vulkanmod.vulkan.texture.VTextureSelector;
@@ -80,7 +81,7 @@ public abstract class MNativeImage {
     public void downloadTexture(int level, boolean removeAlpha) {
         RenderSystem.assertOnRenderThread();
 
-        ImageUtil.downloadTexture(VTextureSelector.getBoundTexture(0), this.pixels);
+        ImageUtil.downloadTexture(Renderer.useMode ? VTextureSelector.getBoundTexture(0) : Vulkan.getSwapChain().getColorAttachment(), this.pixels);
 
         if (removeAlpha && this.format.hasAlpha()) {
             if (this.format != NativeImage.Format.RGBA) {

--- a/src/main/java/net/vulkanmod/vulkan/Renderer.java
+++ b/src/main/java/net/vulkanmod/vulkan/Renderer.java
@@ -4,6 +4,7 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.client.Minecraft;
 import net.vulkanmod.Initializer;
+import net.vulkanmod.gl.GlFramebuffer;
 import net.vulkanmod.mixin.window.WindowAccessor;
 import net.vulkanmod.render.chunk.AreaUploadManager;
 import net.vulkanmod.render.PipelineManager;
@@ -38,12 +39,16 @@ import static org.lwjgl.vulkan.KHRSwapchain.*;
 import static org.lwjgl.vulkan.VK10.*;
 
 public class Renderer {
+    public static boolean recomp;
     private static Renderer INSTANCE;
 
     private static VkDevice device;
 
     private static boolean swapChainUpdate = false;
-    public static boolean skipRendering = false;
+    public static boolean skipRendering, useMode = false;
+
+    private static boolean effectActive,renderPassUpdate,hasCalled = false;
+
     public static void initRenderer() {
         INSTANCE = new Renderer();
         INSTANCE.init();
@@ -57,7 +62,7 @@ public class Renderer {
 
     public static int getCurrentImage() { return imageIndex; }
 
-    private final Set<Pipeline> usedPipelines = new ObjectOpenHashSet<>();
+    private final Set<GraphicsPipeline> usedPipelines = new ObjectOpenHashSet<>();
 
     private Drawer drawer;
 
@@ -75,9 +80,6 @@ public class Renderer {
     private static int imageIndex;
     private VkCommandBuffer currentCmdBuffer;
     private boolean recordingCmds = false;
-
-//    MainPass mainPass = DefaultMainPass.PASS;
-    MainPass mainPass = LegacyMainPass.PASS;
 
     private final List<Runnable> onResizeCallbacks = new ObjectArrayList<>();
 
@@ -171,6 +173,19 @@ public class Renderer {
         Profiler2 p = Profiler2.getMainProfiler();
         p.pop();
         p.push("Frame_fence");
+//        if(recomp)
+//        {
+//            waitIdle();
+//            usedPipelines.forEach(graphicsPipeline -> graphicsPipeline.updateSpecConstant(SPIRVUtils.SpecConstant.USE_FOG));
+//            recomp=false;
+//        }
+        if(renderPassUpdate)
+        {
+            useMode=effectActive;
+            Initializer.LOGGER.error("Using RenderPass: "+ (useMode ? "Post Effect" : "Default"));
+            renderPassUpdate = false;
+        }
+
 
         if(swapChainUpdate) {
             recreateSwapChain();
@@ -209,7 +224,7 @@ public class Renderer {
         resetDescriptors();
 
         currentCmdBuffer = commandBuffers.get(currentFrame);
-        vkResetCommandBuffer(currentCmdBuffer, 0);
+
         recordingCmds = true;
 
         try(MemoryStack stack = stackPush()) {
@@ -242,7 +257,8 @@ public class Renderer {
                 throw new RuntimeException("Failed to begin recording command buffer:" + err);
             }
 
-            mainPass.begin(commandBuffer, stack);
+
+            LegacyMainPass.PASS.begin(commandBuffer, stack);
 
             vkCmdSetDepthBias(commandBuffer, 0.0F, 0.0F, 0.0F);
         }
@@ -257,8 +273,19 @@ public class Renderer {
         Profiler2 p = Profiler2.getMainProfiler();
         p.push("End_rendering");
 
-        mainPass.end(currentCmdBuffer);
+        LegacyMainPass.PASS.end(currentCmdBuffer);
 
+        if(!hasCalled) {
+            if(effectActive) {
+                scheduleRenderPassUpdate();
+            }
+            effectActive = false;
+        }
+        if(renderPassUpdate) {
+            this.endRenderPass();
+            GlFramebuffer.bindFramebuffer(0,0); //Avoid NPE when switching post effect modes
+        }
+        hasCalled=false;
         submitFrame();
         recordingCmds = false;
 
@@ -363,11 +390,11 @@ public class Renderer {
         Vulkan.getStagingBuffer().reset();
     }
 
-    public void addUsedPipeline(Pipeline pipeline) {
+    public void addUsedPipeline(GraphicsPipeline pipeline) {
         usedPipelines.add(pipeline);
     }
 
-    public void removeUsedPipeline(Pipeline pipeline) { usedPipelines.remove(pipeline); }
+    public void removeUsedPipeline(GraphicsPipeline pipeline) { usedPipelines.remove(pipeline); }
 
     private void resetDescriptors() {
         for(Pipeline pipeline : usedPipelines) {
@@ -453,9 +480,9 @@ public class Renderer {
         return boundRenderPass;
     }
 
-    public void setMainPass(MainPass mainPass) { this.mainPass = mainPass; }
+//    public void setMainPass(MainPass mainPass) { this.mainPass = mainPass; }
 
-    public MainPass getMainPass() { return this.mainPass; }
+    public MainPass getMainPass() { return LegacyMainPass.PASS; }
 
     public void addOnResizeCallback(Runnable runnable) {
         this.onResizeCallbacks.add(runnable);
@@ -466,7 +493,7 @@ public class Renderer {
 
         //Debug
         if(boundRenderPass == null)
-            mainPass.mainTargetBindWrite();
+            LegacyMainPass.PASS.mainTargetBindWrite();
 
         PipelineState currentState = PipelineState.getCurrentPipelineState(boundRenderPass);
         vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline.getHandle(currentState));
@@ -590,6 +617,8 @@ public class Renderer {
     }
 
     public static void resetViewport() {
+        if(!effectActive) scheduleRenderPassUpdate();
+        effectActive=hasCalled=true;
         try(MemoryStack stack = stackPush()) {
             int width = getSwapChain().getWidth();
             int height = getSwapChain().getHeight();
@@ -665,4 +694,5 @@ public class Renderer {
     public static boolean isRecording() { return INSTANCE.recordingCmds; }
 
     public static void scheduleSwapChainUpdate() { swapChainUpdate = true; }
+    public static void scheduleRenderPassUpdate() { renderPassUpdate = true; }
 }

--- a/src/main/java/net/vulkanmod/vulkan/Renderer.java
+++ b/src/main/java/net/vulkanmod/vulkan/Renderer.java
@@ -1,5 +1,6 @@
 package net.vulkanmod.vulkan;
 
+import com.mojang.blaze3d.pipeline.RenderTarget;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.client.Minecraft;
@@ -39,7 +40,6 @@ import static org.lwjgl.vulkan.KHRSwapchain.*;
 import static org.lwjgl.vulkan.VK10.*;
 
 public class Renderer {
-    public static boolean recomp;
     private static Renderer INSTANCE;
 
     private static VkDevice device;
@@ -47,7 +47,7 @@ public class Renderer {
     private static boolean swapChainUpdate = false;
     public static boolean skipRendering, useMode = false;
 
-    private static boolean effectActive,renderPassUpdate,hasCalled = false;
+    public static boolean effectActive,renderPassUpdate,hasCalled = false;
 
     public static void initRenderer() {
         INSTANCE = new Renderer();
@@ -181,9 +181,24 @@ public class Renderer {
 //        }
         if(renderPassUpdate)
         {
+//            LegacyMainPass.PASS.mainTargetBindWrite(effectActive);
+//
+//            if(!effectActive)
+//            {
+//                LegacyMainPass.PASS.mainTargetUnbindWrite();
+//            }
+
+            updateRenderPassState();
+
+            //Minecraft.getInstance().gameRenderer.resize(getSwapChain().getWidth(), getSwapChain().getHeight());
+
             useMode=effectActive;
             Initializer.LOGGER.error("Using RenderPass: "+ (useMode ? "Post Effect" : "Default"));
             renderPassUpdate = false;
+
+
+//                GlFramebuffer.framebufferTexture2D(0, GL30.GL_COLOR_ATTACHMENT0, GL30.GL_TEXTURE_2D, 1, 0);
+//                GlFramebuffer.framebufferTexture2D(0, GL30.GL_DEPTH_ATTACHMENT, GL30.GL_TEXTURE_2D, 1, 0);
         }
 
 
@@ -264,6 +279,19 @@ public class Renderer {
         }
 
         p.pop();
+    }
+
+    private static void updateRenderPassState() {
+        RenderTarget renderTarget = Minecraft.getInstance().getMainRenderTarget();
+        int i = getSwapChain().getWidth();
+        int j = getSwapChain().getHeight();
+
+        if (renderTarget.frameBufferId >= 0) {
+            renderTarget.destroyBuffers();
+        }
+
+        renderTarget.createBuffers(i, j, false);
+        GlFramebuffer.bindFramebuffer(36160, 0);
     }
 
     public void endFrame() {

--- a/src/main/java/net/vulkanmod/vulkan/framebuffer/RenderPass.java
+++ b/src/main/java/net/vulkanmod/vulkan/framebuffer/RenderPass.java
@@ -61,7 +61,7 @@ public class RenderPass {
                         .storeOp(colorAttachmentInfo.storeOp)
                         .stencilLoadOp(VK_ATTACHMENT_LOAD_OP_DONT_CARE)
                         .stencilStoreOp(VK_ATTACHMENT_STORE_OP_DONT_CARE)
-                        .initialLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
+                        .initialLayout(VK_IMAGE_LAYOUT_PRESENT_SRC_KHR)
                         .finalLayout(colorAttachmentInfo.finalLayout);
 
                 VkAttachmentReference colorAttachmentRef = attachmentRefs.get(0)
@@ -105,9 +105,10 @@ public class RenderPass {
                         .srcSubpass(VK_SUBPASS_EXTERNAL)
                         .dstSubpass(0)
                         .srcStageMask(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT)
-                        .dstStageMask(VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT)
+                        .dstStageMask(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT)
                         .srcAccessMask(0)
-                        .dstAccessMask(0);
+                        .dstAccessMask(VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT)
+                        .dependencyFlags(VK_DEPENDENCY_BY_REGION_BIT);
 
                 renderPassInfo.pDependencies(subpassDependencies);
             }
@@ -125,8 +126,8 @@ public class RenderPass {
     public void beginRenderPass(VkCommandBuffer commandBuffer, long framebufferId, MemoryStack stack) {
 
         if(colorAttachmentInfo != null
-                && framebuffer.getColorAttachment().getCurrentLayout() != VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
-            framebuffer.getColorAttachment().transitionImageLayout(stack, commandBuffer, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+                && framebuffer.getColorAttachment().getCurrentLayout() != VK_IMAGE_LAYOUT_PRESENT_SRC_KHR)
+            framebuffer.getColorAttachment().transitionImageLayout(stack, commandBuffer, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
         if(depthAttachmentInfo != null
                 && framebuffer.getDepthAttachment().getCurrentLayout() != VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
             framebuffer.getDepthAttachment().transitionImageLayout(stack, commandBuffer, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);

--- a/src/main/java/net/vulkanmod/vulkan/passes/LegacyMainPass.java
+++ b/src/main/java/net/vulkanmod/vulkan/passes/LegacyMainPass.java
@@ -14,38 +14,12 @@ import org.lwjgl.vulkan.VkViewport;
 import static org.lwjgl.vulkan.VK10.*;
 
 public class LegacyMainPass implements MainPass {
-    public static LegacyMainPass PASS = new LegacyMainPass();
-
-    private RenderTarget mainTarget;
-
-    LegacyMainPass() {
-        this.mainTarget = Minecraft.getInstance().getMainRenderTarget();
-    }
+    public static final LegacyMainPass PASS = new LegacyMainPass();
 
     @Override
     public void begin(VkCommandBuffer commandBuffer, MemoryStack stack) {
-    }
-
-    @Override
-    public void mainTargetBindWrite() {
-        RenderTarget mainTarget = Minecraft.getInstance().getMainRenderTarget();
-        mainTarget.bindWrite(true);
-    }
-
-    @Override
-    public void mainTargetUnbindWrite() {
-        RenderTarget mainTarget = Minecraft.getInstance().getMainRenderTarget();
-        mainTarget.unbindWrite();
-    }
-
-    @Override
-    public void end(VkCommandBuffer commandBuffer) {
-        try(MemoryStack stack = MemoryStack.stackPush()) {
-            Renderer.getInstance().endRenderPass(commandBuffer);
-
-            RenderTarget mainTarget = Minecraft.getInstance().getMainRenderTarget();
-            mainTarget.bindRead();
-
+        if(!Renderer.useMode)
+        {
             SwapChain swapChain = Vulkan.getSwapChain();
             swapChain.colorAttachmentLayout(stack, commandBuffer, Renderer.getCurrentImage());
 
@@ -57,9 +31,50 @@ public class LegacyMainPass implements MainPass {
 
             VkRect2D.Buffer pScissor = swapChain.scissor(stack);
             vkCmdSetScissor(commandBuffer, 0, pScissor);
+        }
+    }
 
-            VRenderSystem.disableBlend();
-            Minecraft.getInstance().getMainRenderTarget().blitToScreen(swapChain.getWidth(), swapChain.getHeight());
+    @Override
+    public void mainTargetBindWrite() {
+        if(Renderer.useMode) {
+            RenderTarget mainTarget = Minecraft.getInstance().getMainRenderTarget();
+            mainTarget.bindWrite(true);
+        }
+    }
+
+    @Override
+    public void mainTargetUnbindWrite() {
+        if(Renderer.useMode)
+        {
+            RenderTarget mainTarget = Minecraft.getInstance().getMainRenderTarget();
+            mainTarget.unbindWrite();
+        }
+    }
+
+    @Override
+    public void end(VkCommandBuffer commandBuffer) {
+        if(Renderer.useMode) {
+            try (MemoryStack stack = MemoryStack.stackPush()) {
+                Renderer.getInstance().endRenderPass(commandBuffer);
+
+                RenderTarget mainTarget = Minecraft.getInstance().getMainRenderTarget();
+                mainTarget.bindRead();
+
+                SwapChain swapChain = Vulkan.getSwapChain();
+                swapChain.colorAttachmentLayout(stack, commandBuffer, Renderer.getCurrentImage());
+
+                swapChain.beginRenderPass(commandBuffer, stack);
+                Renderer.getInstance().setBoundFramebuffer(swapChain);
+
+                VkViewport.Buffer pViewport = swapChain.viewport(stack);
+                vkCmdSetViewport(commandBuffer, 0, pViewport);
+
+                VkRect2D.Buffer pScissor = swapChain.scissor(stack);
+                vkCmdSetScissor(commandBuffer, 0, pScissor);
+
+                VRenderSystem.disableBlend();
+                Minecraft.getInstance().getMainRenderTarget().blitToScreen(swapChain.getWidth(), swapChain.getHeight());
+            }
         }
 
         Renderer.getInstance().endRenderPass(commandBuffer);

--- a/src/main/java/net/vulkanmod/vulkan/passes/LegacyMainPass.java
+++ b/src/main/java/net/vulkanmod/vulkan/passes/LegacyMainPass.java
@@ -21,7 +21,7 @@ public class LegacyMainPass implements MainPass {
         if(!Renderer.useMode)
         {
             SwapChain swapChain = Vulkan.getSwapChain();
-            swapChain.colorAttachmentLayout(stack, commandBuffer, Renderer.getCurrentImage());
+//            swapChain.colorAttachmentLayout(stack, commandBuffer, Renderer.getCurrentImage());
 
             swapChain.beginRenderPass(commandBuffer, stack);
             Renderer.getInstance().setBoundFramebuffer(swapChain);

--- a/src/main/java/net/vulkanmod/vulkan/texture/VulkanImage.java
+++ b/src/main/java/net/vulkanmod/vulkan/texture/VulkanImage.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 
 import static net.vulkanmod.vulkan.texture.SamplerManager.*;
 import static org.lwjgl.system.MemoryStack.stackPush;
+import static org.lwjgl.vulkan.KHRSwapchain.*;
 import static org.lwjgl.vulkan.VK10.*;
 
 public class VulkanImage {
@@ -256,7 +257,7 @@ public class VulkanImage {
         int sourceStage, srcAccessMask, destinationStage, dstAccessMask = 0;
 
         switch (image.currentLayout) {
-            case VK_IMAGE_LAYOUT_UNDEFINED -> {
+            case VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR -> {
                 srcAccessMask = 0;
                 sourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
             }
@@ -303,6 +304,9 @@ public class VulkanImage {
             case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL -> {
                 dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
                 destinationStage = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+            }
+            case VK_IMAGE_LAYOUT_PRESENT_SRC_KHR -> {
+                destinationStage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
             }
             default -> throw new RuntimeException("Unexpected value:" + newLayout);
         }


### PR DESCRIPTION
This PR adds two RenderPass related Optimisations: 

* Color Clear Skips:
  * This adds code that automatically skips Color Attachment Clears if the color is the same _i..e has already been applied)
  * Help reduce pipeline stalls, which can improve performance by quite alot in some scenarios
* RenderPass Modes
  * Uses crude Post Effect detection to switch between `DefaultPass` and `LegacyPass` if a Post effect Shader is active
  * Using `DefaultPass` Improves performance by Approx 10%+ in default conditions _(if no additional shaders are active)_