### PR TITLE
Add renderFog Spec Constant + Animations and renderSky options

### DIFF
--- a/src/main/java/net/vulkanmod/config/Config.java
+++ b/src/main/java/net/vulkanmod/config/Config.java
@@ -21,6 +21,9 @@ public class Config {
     public boolean uniqueOpaqueLayer = true;
     public boolean entityCulling = true;
     public int device = -1;
+    public boolean animations = true;
+    public boolean renderSky = true;
+
 
     private static Path path;
 
@@ -28,6 +31,8 @@ public class Config {
             .setPrettyPrinting()
             .excludeFieldsWithModifiers(Modifier.PRIVATE)
             .create();
+
+    public boolean renderFog = true;
 
     public static Config load(Path path) {
         Config config;

--- a/src/main/java/net/vulkanmod/config/Options.java
+++ b/src/main/java/net/vulkanmod/config/Options.java
@@ -154,6 +154,18 @@ public class Options {
                 new RangeOption("Entity Distance", 50, 500, 25,
                         value -> minecraftOptions.entityDistanceScaling().set(value * 0.01),
                         () -> minecraftOptions.entityDistanceScaling().get().intValue() * 100),
+                new SwitchOption("Animations",
+                        value -> config.animations = value,
+                        () -> config.animations),
+                new SwitchOption("Render Sky",
+                        value -> config.renderSky = value,
+                        () -> config.renderSky),
+                new SwitchOption("RenderFog",
+                        value -> {
+                            config.renderFog = value;
+                            Renderer.recomp=true;
+                        },
+                        () -> config.renderFog),
                 new CyclingOption<>("Mipmap Levels",
                         new Integer[]{0, 1, 2, 3, 4},
                         value -> Component.nullToEmpty(value.toString()),

--- a/src/main/java/net/vulkanmod/mixin/render/vertex/VertexBufferM.java
+++ b/src/main/java/net/vulkanmod/mixin/render/vertex/VertexBufferM.java
@@ -3,6 +3,7 @@ package net.vulkanmod.mixin.render.vertex;
 import com.mojang.blaze3d.vertex.BufferBuilder;
 import com.mojang.blaze3d.vertex.VertexBuffer;
 import net.minecraft.client.renderer.ShaderInstance;
+import net.vulkanmod.Initializer;
 import net.vulkanmod.render.VBO;
 import org.joml.Matrix4f;
 import org.spongepowered.asm.mixin.Mixin;
@@ -57,7 +58,8 @@ public class VertexBufferM {
      */
     @Overwrite
     public void drawWithShader(Matrix4f viewMatrix, Matrix4f projectionMatrix, ShaderInstance shader) {
-        vbo.drawWithShader(viewMatrix, projectionMatrix, shader);
+      if(Initializer.CONFIG.renderSky)
+          vbo.drawWithShader(viewMatrix, projectionMatrix, shader);
     }
 
     /**

--- a/src/main/java/net/vulkanmod/mixin/texture/MTextureManager.java
+++ b/src/main/java/net/vulkanmod/mixin/texture/MTextureManager.java
@@ -5,6 +5,7 @@ import net.minecraft.client.renderer.texture.MissingTextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.renderer.texture.Tickable;
 import net.minecraft.resources.ResourceLocation;
+import net.vulkanmod.Initializer;
 import net.vulkanmod.render.texture.SpriteUtil;
 import net.vulkanmod.vulkan.DeviceManager;
 import net.vulkanmod.vulkan.Renderer;
@@ -29,7 +30,7 @@ public abstract class MTextureManager {
      */
     @Overwrite
     public void tick() {
-        if(Renderer.skipRendering)
+        if(Renderer.skipRendering|| !Initializer.CONFIG.animations)
             return;
 
         //Debug D

--- a/src/main/java/net/vulkanmod/vulkan/Renderer.java
+++ b/src/main/java/net/vulkanmod/vulkan/Renderer.java
@@ -44,6 +44,8 @@ public class Renderer {
 
     private static boolean swapChainUpdate = false;
     public static boolean skipRendering = false;
+    public static boolean recomp;
+
     public static void initRenderer() {
         INSTANCE = new Renderer();
         INSTANCE.init();
@@ -57,7 +59,7 @@ public class Renderer {
 
     public static int getCurrentImage() { return imageIndex; }
 
-    private final Set<Pipeline> usedPipelines = new ObjectOpenHashSet<>();
+    private final Set<GraphicsPipeline> usedPipelines = new ObjectOpenHashSet<>();
 
     private Drawer drawer;
 
@@ -171,6 +173,14 @@ public class Renderer {
         Profiler2 p = Profiler2.getMainProfiler();
         p.pop();
         p.push("Frame_fence");
+
+        if(recomp)
+        {
+            waitIdle();
+            usedPipelines.forEach(graphicsPipeline -> graphicsPipeline.updateSpecConstant(SPIRVUtils.SpecConstant.USE_FOG));
+            recomp=false;
+        }
+
 
         if(swapChainUpdate) {
             recreateSwapChain();
@@ -363,7 +373,7 @@ public class Renderer {
         Vulkan.getStagingBuffer().reset();
     }
 
-    public void addUsedPipeline(Pipeline pipeline) {
+    public void addUsedPipeline(GraphicsPipeline pipeline) {
         usedPipelines.add(pipeline);
     }
 

--- a/src/main/java/net/vulkanmod/vulkan/shader/GraphicsPipeline.java
+++ b/src/main/java/net/vulkanmod/vulkan/shader/GraphicsPipeline.java
@@ -12,6 +12,7 @@ import org.lwjgl.vulkan.*;
 
 import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,9 +27,11 @@ public class GraphicsPipeline extends Pipeline {
 
     private final Map<PipelineState, Long> graphicsPipelines = new HashMap<>();
     private final VertexFormat vertexFormat;
+    private final EnumSet<SPIRVUtils.SpecConstant> specConstants;
 
     private long vertShaderModule = 0;
     private long fragShaderModule = 0;
+    private PipelineState state;
 
     GraphicsPipeline(Builder builder) {
         super(builder.shaderPath);
@@ -37,14 +40,17 @@ public class GraphicsPipeline extends Pipeline {
         this.imageDescriptors = builder.imageDescriptors;
         this.pushConstants = builder.pushConstants;
         this.vertexFormat = builder.vertexFormat;
+        this.specConstants = builder.specConstants;
 
         createDescriptorSetLayout();
         createPipelineLayout();
         createShaderModules(builder.vertShaderSPIRV, builder.fragShaderSPIRV);
 
-        if(builder.renderPass != null)
-            graphicsPipelines.computeIfAbsent(new PipelineState(DEFAULT_BLEND_STATE, DEFAULT_DEPTH_STATE, DEFAULT_LOGICOP_STATE, DEFAULT_COLORMASK, builder.renderPass),
+        if(builder.renderPass != null) {
+            this.state = new PipelineState(DEFAULT_BLEND_STATE, DEFAULT_DEPTH_STATE, DEFAULT_LOGICOP_STATE, DEFAULT_COLORMASK, builder.renderPass);
+            graphicsPipelines.computeIfAbsent(state,
                     this::createGraphicsPipeline);
+        }
 
         createDescriptorSets(Renderer.getFramesNum());
 
@@ -56,12 +62,22 @@ public class GraphicsPipeline extends Pipeline {
     }
 
     private long createGraphicsPipeline(PipelineState state) {
-
+        this.state=state;
         try(MemoryStack stack = stackPush()) {
 
             ByteBuffer entryPoint = stack.UTF8("main");
 
             VkPipelineShaderStageCreateInfo.Buffer shaderStages = VkPipelineShaderStageCreateInfo.calloc(2, stack);
+
+
+            VkSpecializationMapEntry.Buffer specEntrySet =  VkSpecializationMapEntry.malloc(specConstants.size(), stack);
+
+
+            boolean equals = !this.specConstants.isEmpty();
+            VkSpecializationInfo specInfo = equals ? VkSpecializationInfo.malloc(stack)
+                    .pMapEntries(specEntrySet)
+                    .pData(enumSpecConstants(stack, specEntrySet)) : null;
+
 
             VkPipelineShaderStageCreateInfo vertShaderStageInfo = shaderStages.get(0);
 
@@ -69,6 +85,7 @@ public class GraphicsPipeline extends Pipeline {
             vertShaderStageInfo.stage(VK_SHADER_STAGE_VERTEX_BIT);
             vertShaderStageInfo.module(vertShaderModule);
             vertShaderStageInfo.pName(entryPoint);
+            vertShaderStageInfo.pSpecializationInfo(specInfo);
 
             VkPipelineShaderStageCreateInfo fragShaderStageInfo = shaderStages.get(1);
 
@@ -76,6 +93,7 @@ public class GraphicsPipeline extends Pipeline {
             fragShaderStageInfo.stage(VK_SHADER_STAGE_FRAGMENT_BIT);
             fragShaderStageInfo.module(fragShaderModule);
             fragShaderStageInfo.pName(entryPoint);
+            fragShaderStageInfo.pSpecializationInfo(specInfo);
 
             // ===> VERTEX STAGE <===
 
@@ -202,6 +220,30 @@ public class GraphicsPipeline extends Pipeline {
 
             return pGraphicsPipeline.get(0);
         }
+    }
+
+
+    private ByteBuffer enumSpecConstants(MemoryStack stack, VkSpecializationMapEntry.Buffer specEntrySet) {
+        int i = 0;
+        int x = 0;
+        ByteBuffer byteBuffer = stack.malloc(specConstants.size()*Integer.BYTES);
+
+        for(var specDef : specConstants)
+        {
+            specEntrySet.get(i)
+                    .constantID(specDef.ordinal())
+                    .offset(x)
+                    .size(4);
+
+            byteBuffer.putInt(i, specDef.getValue());
+            i++; x+=4;
+        }
+        return byteBuffer;
+    }
+
+    //Vulkan spec mandates that VkBool32 must always be aligned to uint32_t, which is 4 Bytes
+    private static ByteBuffer alignedVkBool32(MemoryStack stack, int i) {
+        return stack.malloc(Integer.BYTES).putInt(0, i); //Malloc as Int is always Unaligned, so asIntBuffer doesn't help here afaik
     }
 
     private void createShaderModules(SPIRVUtils.SPIRV vertSpirv, SPIRVUtils.SPIRV fragSpirv) {
@@ -336,6 +378,28 @@ public class GraphicsPipeline extends Pipeline {
         }
 
         return attributeDescriptions.rewind();
+    }
+
+    // SpecConstants can be set to be unique per Pipeline
+    // but that would involve adding boilerplate to PipelineState
+    // So to simplify the code, SpecConstants are limited to "Static Global State" rn
+    public void updateSpecConstant(SPIRVUtils.SpecConstant specConstant)
+    {
+
+        if(this.specConstants.contains(specConstant))
+        {
+            if(graphicsPipelines.size()>1)
+            {
+                graphicsPipelines.values().forEach(pipeline -> vkDestroyPipeline(DeviceManager.device, pipeline, null));
+                graphicsPipelines.clear();
+            }
+            this.graphicsPipelines.put(this.state, this.createGraphicsPipeline(this.state));
+        }
+//        PIPELINES.remove(this);
+//        Renderer.getInstance().removeUsedPipeline(this);
+//        this.graphicsPipelines.remove(this.state);
+//        PIPELINES.add(this);
+//        Renderer.getInstance().addUsedPipeline(this);
     }
 
     public void cleanUp() {

--- a/src/main/java/net/vulkanmod/vulkan/shader/Pipeline.java
+++ b/src/main/java/net/vulkanmod/vulkan/shader/Pipeline.java
@@ -554,7 +554,7 @@ public abstract class Pipeline {
 //                String type2 = GsonHelper.getAsString(jsonobject2, "type");
 
 
-                this.specConstants.add(SpecConstant.getNamed(name));
+                this.specConstants.add(SpecConstant.valueOf(name));
             }
 
         }

--- a/src/main/java/net/vulkanmod/vulkan/shader/Pipeline.java
+++ b/src/main/java/net/vulkanmod/vulkan/shader/Pipeline.java
@@ -442,6 +442,8 @@ public abstract class Pipeline {
 
     public static class Builder {
 
+        final EnumSet<SpecConstant> specConstants = EnumSet.noneOf(SpecConstant.class);
+
         public static GraphicsPipeline createGraphicsPipeline(VertexFormat format, String path) {
             Pipeline.Builder pipelineBuilder = new Pipeline.Builder(format, path);
             pipelineBuilder.parseBindingsJSON();
@@ -516,6 +518,7 @@ public abstract class Pipeline {
             JsonArray jsonManualUbos = GsonHelper.getAsJsonArray(jsonObject, "ManualUBOs", null);
             JsonArray jsonSamplers = GsonHelper.getAsJsonArray(jsonObject, "samplers", null);
             JsonArray jsonPushConstants = GsonHelper.getAsJsonArray(jsonObject, "PushConstants", null);
+            JsonArray jsonSpecConstants = GsonHelper.getAsJsonArray(jsonObject, "SpecConstants", null);
 
             if (jsonUbos != null) {
                 for (JsonElement jsonelement : jsonUbos) {
@@ -536,6 +539,24 @@ public abstract class Pipeline {
             if(jsonPushConstants != null) {
                 this.parsePushConstantNode(jsonPushConstants);
             }
+            if(jsonSpecConstants != null) {
+                this.parseSpecConstantNode(jsonSpecConstants);
+            }
+        }
+
+        private void parseSpecConstantNode(JsonArray jsonSpecConstants) {
+//            AlignedStruct.Builder builder = new AlignedStruct.Builder();
+
+            for(JsonElement jsonelement : jsonSpecConstants) {
+                JsonObject jsonobject2 = GsonHelper.convertToJsonObject(jsonelement, "SC");
+
+                String name = GsonHelper.getAsString(jsonobject2, "name");
+//                String type2 = GsonHelper.getAsString(jsonobject2, "type");
+
+
+                this.specConstants.add(SpecConstant.getNamed(name));
+            }
+
         }
 
         private void parseUboNode(JsonElement jsonelement) {

--- a/src/main/java/net/vulkanmod/vulkan/shader/SPIRVUtils.java
+++ b/src/main/java/net/vulkanmod/vulkan/shader/SPIRVUtils.java
@@ -131,17 +131,7 @@ public class SPIRVUtils {
         COMPUTE_SIZE_X;
 
         //Ordinals are used to provide the Constant_ID for VkSpecializationMapEntry
-        public static SpecConstant getNamed(String name) {
-            return switch (name)
-            {
-                case "USE_FOG" -> USE_FOG;
-                case "ALPHA_CUTOUT" -> ALPHA_CUTOUT;
-                case "MAX_OFFSET_COUNT" -> MAX_OFFSET_COUNT;
-                case "COMPUTE_SIZE_Y" -> COMPUTE_SIZE_Y;
-                case "COMPUTE_SIZE_X" -> COMPUTE_SIZE_X;
-                default -> null;
-            };
-        }
+
 
         //Vulkan spec mandates that VkBool32 must always be aligned to uint32_t, which is 4 Bytes
         //As a result to simplify alignment, ints are used for all types, regardless if its a bool, float, int or uint

--- a/src/main/java/net/vulkanmod/vulkan/shader/SPIRVUtils.java
+++ b/src/main/java/net/vulkanmod/vulkan/shader/SPIRVUtils.java
@@ -1,6 +1,8 @@
 package net.vulkanmod.vulkan.shader;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.vulkanmod.Initializer;
+import net.vulkanmod.vulkan.VRenderSystem;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.MemoryUtil;
 import org.lwjgl.system.NativeResource;
@@ -117,6 +119,37 @@ public class SPIRVUtils {
         }
         throw new RuntimeException("unable to read inputStream");
     }
+
+
+
+    public enum SpecConstant
+    {
+        USE_FOG(Boolean.class),
+        ALPHA_CUTOUT(Float.class);
+
+        SpecConstant(Object floatClass) {
+
+        }
+
+        public static SpecConstant getNamed(String name) {
+            return switch (name)
+            {
+                case "USE_FOG" -> USE_FOG;
+                case "ALPHA_CUTOUT" -> ALPHA_CUTOUT;
+                default -> null;
+            };
+        }
+
+        //Vulkan spec mandates that VkBool32 must always be aligned to uint32_t, which is 4 Bytes
+        public int getValue()
+        {
+            return switch (this){
+                case USE_FOG -> Initializer.CONFIG.renderFog ? 1 : 0;
+                case ALPHA_CUTOUT -> Float.floatToRawIntBits(VRenderSystem.alphaCutout);
+            };
+        }
+    }
+
 
     public enum ShaderKind {
         VERTEX_SHADER(shaderc_glsl_vertex_shader),

--- a/src/main/resources/assets/vulkanmod/shaders/basic/terrain_direct/terrain_direct.fsh
+++ b/src/main/resources/assets/vulkanmod/shaders/basic/terrain_direct/terrain_direct.fsh
@@ -1,5 +1,5 @@
 #version 450
-
+layout (constant_id = 0) const bool USE_FOG = true;
 #include "light.glsl"
 
 layout(binding = 2) uniform sampler2D Sampler0;
@@ -24,5 +24,5 @@ void main() {
     if (color.a < AlphaCutout) {
         discard;
     }
-    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+    fragColor = USE_FOG ? linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor) : color; //Optimised out by Driver
 }

--- a/src/main/resources/assets/vulkanmod/shaders/basic/terrain_direct/terrain_direct.vsh
+++ b/src/main/resources/assets/vulkanmod/shaders/basic/terrain_direct/terrain_direct.vsh
@@ -1,5 +1,5 @@
 #version 460
-
+layout (constant_id = 0) const bool USE_FOG = true;
 #include "light.glsl"
 
 layout(binding = 0) uniform UniformBufferObject {
@@ -31,8 +31,7 @@ const float POSITION_INV = 1.0 / 1900.0;
 void main() {
     vec3 pos = (Position * POSITION_INV);
     gl_Position = MVP * vec4(pos + ChunkOffset, 1.0);
-
-    vertexDistance = length((ModelViewMat * vec4(pos + ChunkOffset, 1.0)).xyz);
+    vertexDistance = USE_FOG ? length((ModelViewMat * vec4(pos + ChunkOffset, 1.0)).xyz) : 0.0f; //Optimised out by Driver
     vertexColor = Color * sample_lightmap(Sampler2, UV2);
     texCoord0 = UV0 * UV_INV;
 //    normal = MVP * vec4(Normal, 0.0);

--- a/src/main/resources/assets/vulkanmod/shaders/basic/terrain_indirect/terrain_indirect.fsh
+++ b/src/main/resources/assets/vulkanmod/shaders/basic/terrain_indirect/terrain_indirect.fsh
@@ -1,5 +1,5 @@
 #version 450
-
+layout (constant_id = 0) const bool USE_FOG = true;
 #include "light.glsl"
 
 layout(binding = 3) uniform sampler2D Sampler0;
@@ -24,5 +24,5 @@ void main() {
     if (color.a < AlphaCutout) {
         discard;
     }
-    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+    fragColor = USE_FOG ? linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor) : color; //Optimised out by Driver
 }

--- a/src/main/resources/assets/vulkanmod/shaders/basic/terrain_indirect/terrain_indirect.json
+++ b/src/main/resources/assets/vulkanmod/shaders/basic/terrain_indirect/terrain_indirect.json
@@ -21,7 +21,6 @@
         { "name": "ModelViewMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
         { "name": "ProjMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
         { "name": "ChunkOffset", "type": "float", "count": 3, "values": [ 0.0, 0.0, 0.0 ] },
-        { "name": "ColorModulator", "type": "float", "count": 4, "values": [ 1.0, 1.0, 1.0, 1.0 ] },
         { "name": "FogStart", "type": "float", "count": 1, "values": [ 0.0 ] },
         { "name": "FogEnd", "type": "float", "count": 1, "values": [ 1.0 ] },
         { "name": "FogColor", "type": "float", "count": 4, "values": [ 0.0, 0.0, 0.0, 0.0 ] }
@@ -41,5 +40,8 @@
     ],
     "ManualUBOs" : [
         { "type":  "vertex", "binding": 2, "size": 2048 }
+    ],
+    "SpecConstants": [
+        { "name":  "USE_FOG", "type": "bool" }
     ]
 }

--- a/src/main/resources/assets/vulkanmod/shaders/basic/terrain_indirect/terrain_indirect.vsh
+++ b/src/main/resources/assets/vulkanmod/shaders/basic/terrain_indirect/terrain_indirect.vsh
@@ -1,6 +1,6 @@
 #version 460
-
-#define MAX_OFFSET_COUNT 512
+layout (constant_id = 0) const bool USE_FOG = true;
+layout (constant_id = 2) const uint MAX_OFFSET_COUNT = 512;
 
 #include "light.glsl"
 
@@ -35,7 +35,7 @@ void main() {
     vec3 pos = (Position * POSITION_INV);
     gl_Position = MVP * vec4(pos + ChunkOffset[gl_DrawID], 1.0);
 
-    vertexDistance = length((ModelViewMat * vec4(pos + ChunkOffset[gl_DrawID], 1.0)).xyz);
+    vertexDistance = USE_FOG ? length((ModelViewMat * vec4(pos + ChunkOffset[gl_DrawID], 1.0)).xyz) : 0.0f; //Optimised out by Driver
     vertexColor = Color * sample_lightmap(Sampler2, UV2);
     texCoord0 = UV0 * UV_INV;
     //    normal = MVP * vec4(Normal, 0.0);

--- a/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_beacon_beam/rendertype_beacon_beam.fsh
+++ b/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_beacon_beam/rendertype_beacon_beam.fsh
@@ -1,5 +1,5 @@
 #version 450
-
+layout (constant_id = 0) const bool USE_FOG = true;
 vec4 linear_fog(vec4 inColor, float vertexDistance, float fogStart, float fogEnd, vec4 fogColor) {
     if (vertexDistance <= fogStart) {
         return inColor;
@@ -32,7 +32,7 @@ void main() {
     vec4 color = texture(Sampler0, texCoord0);
     color *= vertexColor * ColorModulator;
     float fragmentDistance = -ProjMat[3].z / ((gl_FragCoord.z) * -2.0 + 1.0 - ProjMat[2].z);
-    fragColor = linear_fog(color, fragmentDistance, FogStart, FogEnd, FogColor);
+    fragColor = USE_FOG ? linear_fog(color, fragmentDistance, FogStart, FogEnd, FogColor) : color;
 }
 
 /*

--- a/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_beacon_beam/rendertype_beacon_beam.json
+++ b/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_beacon_beam/rendertype_beacon_beam.json
@@ -33,5 +33,8 @@
             { "name": "FogStart", "type": "float", "count": 1, "values": [ 0.0 ] },
             { "name": "FogEnd", "type": "float", "count": 1, "values": [ 1.0 ] }
         ] }
+    ],
+    "SpecConstants": [
+        { "name":  "USE_FOG", "type": "bool" }
     ]
 }

--- a/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_entity_cutout_no_cull/rendertype_entity_cutout_no_cull.fsh
+++ b/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_entity_cutout_no_cull/rendertype_entity_cutout_no_cull.fsh
@@ -1,5 +1,5 @@
 #version 450
-
+layout (constant_id = 0) const bool USE_FOG = true;
 vec4 linear_fog(vec4 inColor, float vertexDistance, float fogStart, float fogEnd, vec4 fogColor) {
     if (vertexDistance <= fogStart) {
         return inColor;
@@ -35,5 +35,5 @@ void main() {
     color *= vertexColor * ColorModulator;
     color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
     color *= lightMapColor;
-    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+    fragColor = USE_FOG ? linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor) : color;
 }

--- a/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_entity_cutout_no_cull/rendertype_entity_cutout_no_cull.json
+++ b/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_entity_cutout_no_cull/rendertype_entity_cutout_no_cull.json
@@ -42,5 +42,8 @@
             { "name": "FogStart", "type": "float", "count": 1, "values": [ 0.0 ] },
             { "name": "FogEnd", "type": "float", "count": 1, "values": [ 1.0 ] }
         ] }
+    ],
+    "SpecConstants": [
+        { "name":  "USE_FOG", "type": "bool" }
     ]
 }

--- a/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_entity_cutout_no_cull/rendertype_entity_cutout_no_cull.vsh
+++ b/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_entity_cutout_no_cull/rendertype_entity_cutout_no_cull.vsh
@@ -1,5 +1,5 @@
 #version 450
-
+layout (constant_id = 0) const bool USE_FOG = true;
 #include "light.glsl"
 
 layout(location = 0) in vec3 Position;
@@ -29,7 +29,7 @@ layout(location = 5) out float vertexDistance;
 void main() {
     gl_Position = MVP * vec4(Position, 1.0);
 
-    vertexDistance = length((ModelViewMat * vec4(Position, 1.0)).xyz);
+    vertexDistance = USE_FOG ? length((ModelViewMat * vec4(Position, 1.0)).xyz) : 0.0f;
     vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
     lightMapColor = texelFetch(Sampler2, UV2 / 16, 0);
     overlayColor = texelFetch(Sampler1, UV1, 0);

--- a/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_entity_solid/rendertype_entity_solid.fsh
+++ b/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_entity_solid/rendertype_entity_solid.fsh
@@ -1,5 +1,5 @@
 #version 450
-
+layout (constant_id = 0) const bool USE_FOG = true;
 vec4 linear_fog(vec4 inColor, float vertexDistance, float fogStart, float fogEnd, vec4 fogColor) {
     if (vertexDistance <= fogStart) {
         return inColor;
@@ -31,7 +31,7 @@ void main() {
     vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
     color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
     color *= lightMapColor;
-    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+    fragColor = USE_FOG ? linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor) : color;
 }
 
 /*

--- a/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_entity_solid/rendertype_entity_solid.json
+++ b/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_entity_solid/rendertype_entity_solid.json
@@ -42,5 +42,8 @@
             { "name": "FogStart", "type": "float", "count": 1, "values": [ 0.0 ] },
             { "name": "FogEnd", "type": "float", "count": 1, "values": [ 1.0 ] }
         ] }
+    ],
+    "SpecConstants": [
+        { "name":  "USE_FOG", "type": "bool" }
     ]
 }

--- a/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_entity_solid/rendertype_entity_solid.vsh
+++ b/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_entity_solid/rendertype_entity_solid.vsh
@@ -1,5 +1,5 @@
 #version 450
-
+layout (constant_id = 0) const bool USE_FOG = true;
 #include "light.glsl"
 
 layout(location = 0) in vec3 Position;
@@ -29,7 +29,7 @@ layout(location = 5) out float vertexDistance;
 void main() {
     gl_Position = MVP * vec4(Position, 1.0);
 
-    vertexDistance = length((ModelViewMat * vec4(Position, 1.0)).xyz);
+    vertexDistance = USE_FOG ? length((ModelViewMat * vec4(Position, 1.0)).xyz) : 0.0f;
     vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
     lightMapColor = texelFetch(Sampler2, UV2 / 16, 0);
     overlayColor = texelFetch(Sampler1, UV1, 0);

--- a/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_entity_translucent/rendertype_entity_translucent.fsh
+++ b/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_entity_translucent/rendertype_entity_translucent.fsh
@@ -1,5 +1,5 @@
 #version 450
-
+layout (constant_id = 0) const bool USE_FOG = true;
 vec4 linear_fog(vec4 inColor, float vertexDistance, float fogStart, float fogEnd, vec4 fogColor) {
     if (vertexDistance <= fogStart) {
         return inColor;
@@ -35,7 +35,7 @@ void main() {
     color *= vertexColor * ColorModulator;
     color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
     color *= lightMapColor;
-    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+    fragColor = USE_FOG ? linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor) : color;
 }
 
 /*

--- a/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_entity_translucent/rendertype_entity_translucent.json
+++ b/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_entity_translucent/rendertype_entity_translucent.json
@@ -42,5 +42,8 @@
             { "name": "FogStart", "type": "float", "count": 1, "values": [ 0.0 ] },
             { "name": "FogEnd", "type": "float", "count": 1, "values": [ 1.0 ] }
         ] }
+    ],
+    "SpecConstants": [
+        { "name":  "USE_FOG", "type": "bool" }
     ]
 }

--- a/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_entity_translucent/rendertype_entity_translucent.vsh
+++ b/src/main/resources/assets/vulkanmod/shaders/minecraft/core/rendertype_entity_translucent/rendertype_entity_translucent.vsh
@@ -1,5 +1,5 @@
 #version 450
-
+layout (constant_id = 0) const bool USE_FOG = true;
 #include "light.glsl"
 
 layout(location = 0) in vec3 Position;
@@ -29,7 +29,7 @@ layout(location = 5) out float vertexDistance;
 void main() {
     gl_Position = MVP * vec4(Position, 1.0);
 
-    vertexDistance = length((ModelViewMat * vec4(Position, 1.0)).xyz);
+    vertexDistance = USE_FOG ? length((ModelViewMat * vec4(Position, 1.0)).xyz) : 0.0f;
     vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
     lightMapColor = texelFetch(Sampler2, UV2 / 16, 0);
     overlayColor = texelFetch(Sampler1, UV1, 0);


### PR DESCRIPTION
Adds basic Graphics options inspired by Optifine, namely Animation, Sky and Render Fog toggles

The RenderFog Toggle uses a SPIR-V exclusive feature called Specalization Constants, which enables dynamically modifying shader code during runtime without Shader recompilations

Allowing to the ability to disable specific effects whilst being able to apply shader optimisations at the same time
