### PR TITLE
Fix custom shader NPE

### DIFF
--- a/src/main/java/net/vulkanmod/mixin/render/ShaderInstanceM.java
+++ b/src/main/java/net/vulkanmod/mixin/render/ShaderInstanceM.java
@@ -73,7 +73,9 @@ public class ShaderInstanceM implements ShaderMixed {
 
         try {
             if(Pipeline.class.getResourceAsStream(String.format("/assets/vulkanmod/shaders/minecraft/core/%s/%s.json", name, name)) == null) {
-                createLegacyShader(resourceProvider, new ResourceLocation("shaders/core/" + name + ".json"), format);
+                // fix shader npe creating from FabricShaderProgram (path exception)
+                ResourceLocation res = ResourceLocation(name)
+                createLegacyShader(resourceProvider, new ResourceLocation(res.getNamespace(), "shaders/core/" + res.getPath() + ".json"), format);
                 return;
             }
 

--- a/src/main/java/net/vulkanmod/mixin/render/ShaderInstanceM.java
+++ b/src/main/java/net/vulkanmod/mixin/render/ShaderInstanceM.java
@@ -73,8 +73,8 @@ public class ShaderInstanceM implements ShaderMixed {
 
         try {
             if(Pipeline.class.getResourceAsStream(String.format("/assets/vulkanmod/shaders/minecraft/core/%s/%s.json", name, name)) == null) {
-                // fix shader npe creating from FabricShaderProgram (path exception)
-                ResourceLocation res = ResourceLocation(name)
+                // fix shader npe creating from FabricShaderProgram (path exception), close issue #370
+                ResourceLocation res = ResourceLocation(name);
                 createLegacyShader(resourceProvider, new ResourceLocation(res.getNamespace(), "shaders/core/" + res.getPath() + ".json"), format);
                 return;
             }


### PR DESCRIPTION
Close #364 
[crash-2024-02-02_08.40.32-client.txt](https://github.com/xCollateral/VulkanMod/files/14138373/crash-2024-02-02_08.40.32-client.txt)
@thr3343 After debugging, I found that the real exception happens in this mixin, it had been hard coded and cannot build the shader path correctly. 
