### PR TITLE
Fix _getTexLevelParameter returning -1 for everything

### DIFF
--- a/src/main/java/net/vulkanmod/gl/GlRenderbuffer.java
+++ b/src/main/java/net/vulkanmod/gl/GlRenderbuffer.java
@@ -78,7 +78,7 @@ public class GlRenderbuffer {
     }
 
     public static int getTexLevelParameter(int target, int level, int pName) {
-        if(bound == null || target == GL11.GL_TEXTURE_2D)
+        if(bound == null || target != GL11.GL_TEXTURE_2D)
             return -1;
 
         return switch (pName) {

--- a/src/main/java/net/vulkanmod/gl/GlTexture.java
+++ b/src/main/java/net/vulkanmod/gl/GlTexture.java
@@ -109,7 +109,7 @@ public class GlTexture {
     }
 
     public static int getTexLevelParameter(int target, int level, int pName) {
-        if(boundTexture == null || target == GL11.GL_TEXTURE_2D)
+        if(boundTexture == null || target != GL11.GL_TEXTURE_2D)
             return -1;
 
         return switch (pName) {


### PR DESCRIPTION
Changed `target == GL11.GL_TEXTURE_2D` to `target != GL11.GL_TEXTURE_2D`.

This fixes compatibility with Mine Little Pony and possibly other mods that make use of GlStateManager._getTexLevelParameter