### PR TITLE
[Wayland-Fixes] Fix Gnome Window Decorators + Add Xwayland and tear control support

### DIFF
--- a/src/main/java/net/vulkanmod/Initializer.java
+++ b/src/main/java/net/vulkanmod/Initializer.java
@@ -26,7 +26,6 @@ public class Initializer implements ClientModInitializer {
 
 		LOGGER.info("== VulkanMod ==");
 
-		VideoResolution.init();
 
 		var configPath = FabricLoader.getInstance()
 				.getConfigDir()
@@ -34,14 +33,15 @@ public class Initializer implements ClientModInitializer {
 
 		CONFIG = loadConfig(configPath);
 
+		VideoResolution.init();
 	}
 
 	private static Config loadConfig(Path path) {
 		Config config = Config.load(path);
 		if(config == null) {
 			config = new Config();
-			config.write();
 		}
+		config.write();
 		return config;
 	}
 

--- a/src/main/java/net/vulkanmod/Initializer.java
+++ b/src/main/java/net/vulkanmod/Initializer.java
@@ -26,7 +26,6 @@ public class Initializer implements ClientModInitializer {
 
 		LOGGER.info("== VulkanMod ==");
 
-
 		var configPath = FabricLoader.getInstance()
 				.getConfigDir()
 				.resolve("vulkanmod_settings.json");
@@ -38,10 +37,12 @@ public class Initializer implements ClientModInitializer {
 
 	private static Config loadConfig(Path path) {
 		Config config = Config.load(path);
+
 		if(config == null) {
 			config = new Config();
+			config.write();
 		}
-		config.write();
+
 		return config;
 	}
 

--- a/src/main/java/net/vulkanmod/config/Config.java
+++ b/src/main/java/net/vulkanmod/config/Config.java
@@ -14,6 +14,7 @@ public class Config {
 
     public int frameQueueSize = 2;
     public VideoResolution resolution = VideoResolution.getFirstAvailable();
+    public boolean xWayland = false;
     public boolean windowedFullscreen = false;
     public boolean guiOptimizations = false;
     public int advCulling = 2;

--- a/src/main/java/net/vulkanmod/config/Config.java
+++ b/src/main/java/net/vulkanmod/config/Config.java
@@ -2,6 +2,7 @@ package net.vulkanmod.config;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.lwjgl.vulkan.KHRSurface;
 
 import java.io.FileReader;
 import java.io.IOException;
@@ -14,6 +15,7 @@ public class Config {
 
     public int frameQueueSize = 2;
     public VideoResolution resolution = VideoResolution.getFirstAvailable();
+    public int uncappedMode = VideoResolution.isWayLand() ? KHRSurface.VK_PRESENT_MODE_MAILBOX_KHR : KHRSurface.VK_PRESENT_MODE_IMMEDIATE_KHR;
     public boolean xWayland = false;
     public boolean windowedFullscreen = false;
     public boolean guiOptimizations = false;
@@ -24,7 +26,6 @@ public class Config {
     public boolean uniqueOpaqueLayer = true;
     public boolean entityCulling = true;
     public int device = -1;
-
     private static Path path;
 
     private static final Gson GSON = new GsonBuilder()

--- a/src/main/java/net/vulkanmod/config/Config.java
+++ b/src/main/java/net/vulkanmod/config/Config.java
@@ -2,7 +2,6 @@ package net.vulkanmod.config;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import org.lwjgl.vulkan.KHRSurface;
 
 import java.io.FileReader;
 import java.io.IOException;
@@ -15,7 +14,6 @@ public class Config {
 
     public int frameQueueSize = 2;
     public VideoResolution resolution = VideoResolution.getFirstAvailable();
-    public int uncappedMode = VideoResolution.isWayLand() ? KHRSurface.VK_PRESENT_MODE_MAILBOX_KHR : KHRSurface.VK_PRESENT_MODE_IMMEDIATE_KHR;
     public boolean xWayland = false;
     public boolean windowedFullscreen = false;
     public boolean guiOptimizations = false;
@@ -26,6 +24,7 @@ public class Config {
     public boolean uniqueOpaqueLayer = true;
     public boolean entityCulling = true;
     public int device = -1;
+
     private static Path path;
 
     private static final Gson GSON = new GsonBuilder()

--- a/src/main/java/net/vulkanmod/config/Options.java
+++ b/src/main/java/net/vulkanmod/config/Options.java
@@ -7,8 +7,6 @@ import net.minecraft.network.chat.Component;
 import net.vulkanmod.Initializer;
 import net.vulkanmod.vulkan.DeviceManager;
 import net.vulkanmod.vulkan.Renderer;
-import net.vulkanmod.vulkan.framebuffer.SwapChain;
-import org.lwjgl.vulkan.KHRSurface;
 
 import java.util.stream.IntStream;
 
@@ -17,8 +15,6 @@ public class Options {
     static Config config = Initializer.CONFIG;
     static Window window = Minecraft.getInstance().getWindow();
     public static boolean fullscreenDirty = false;
-
-    private static final Integer[] uncappedModes = SwapChain.checkPresentModes(KHRSurface.VK_PRESENT_MODE_IMMEDIATE_KHR, KHRSurface.VK_PRESENT_MODE_MAILBOX_KHR);
 
     public static Option<?>[] getVideoOpts() {
         return new Option[] {
@@ -58,23 +54,6 @@ public class Options {
                             Minecraft.getInstance().getWindow().updateVsync(value);
                         },
                         () -> minecraftOptions.enableVsync().get()),
-                new CyclingOption<>("Screen Tearing",
-                        uncappedModes,
-                        value -> Component.nullToEmpty(value==KHRSurface.VK_PRESENT_MODE_IMMEDIATE_KHR?  "Yes (Immediate)" : "No (FastSync)"),
-                        value -> {
-                            config.uncappedMode =value;
-                            if(!minecraftOptions.enableVsync().get()) {
-                                Renderer.scheduleSwapChainUpdate();
-                            }
-                        },
-                        () -> config.uncappedMode).setTooltip(Component.nullToEmpty("""
-                        Configures screen tearing if supported by the GPU driver:
-                        
-                        Yes: Immediate (Lowest latency, screen tearing)
-                        No: FastSync (Higher latency, no screen tearing)
-
-                        Available modes vary on GPU driver + platform
-                        """)),
                 new CyclingOption<>("Gui Scale",
                         new Integer[]{0, 1, 2, 3, 4},
                         value -> value == 0 ? Component.literal("Auto") : Component.literal(value.toString()),

--- a/src/main/java/net/vulkanmod/config/VideoResolution.java
+++ b/src/main/java/net/vulkanmod/config/VideoResolution.java
@@ -17,7 +17,7 @@ import static org.lwjgl.glfw.GLFW.*;
 public class VideoResolution {
     private static VideoResolution[] videoResolutions;
     private static final int activePlat = getSupportedPlat();
-    private static final String activeDE=determineDE();
+    private static final String activeDE = determineDE();
 
     int width;
     int height;
@@ -59,12 +59,14 @@ public class VideoResolution {
 
     public static void init() {
         RenderSystem.assertOnRenderThread();
+
         boolean useXwaylandOverride = Initializer.CONFIG.xWayland && isWayLand();
         int overriddenPlat = useXwaylandOverride ? GLFW_PLATFORM_X11 : activePlat;
         GLFW.glfwInitHint(GLFW_PLATFORM, overriddenPlat);
         LOGGER.info("Selecting Platform: " + (useXwaylandOverride ? getStringFromPlat(overriddenPlat) + " (Xwayland Override)" : getStringFromPlat(overriddenPlat) ));
-        if(SystemUtils.IS_OS_LINUX) LOGGER.info("Desktop Environment: "+activeDE);
-        LOGGER.info("GLFW: "+GLFW.glfwGetVersionString());
+        if(SystemUtils.IS_OS_LINUX) LOGGER.info("Desktop Environment: " + activeDE);
+
+        LOGGER.info("GLFW: " + GLFW.glfwGetVersionString());
         GLFW.glfwInit();
         videoResolutions = populateVideoResolutions(GLFW.glfwGetPrimaryMonitor());
     }

--- a/src/main/java/net/vulkanmod/config/VideoResolution.java
+++ b/src/main/java/net/vulkanmod/config/VideoResolution.java
@@ -119,7 +119,7 @@ public class VideoResolution {
     public static boolean isAndroid() { return activePlat == GLFW_ANY_PLATFORM; }
 
     //Desktop Environment Names: https://wiki.archlinux.org/title/Environment_variables_#Examples
-    public static boolean isGNOME(){return activeDE.contains("gnome") || activeDE.contains("GNOME");}
+    public static boolean isGnome() { return activeDE.contains("gnome"); }
 
 
 

--- a/src/main/java/net/vulkanmod/config/VideoResolution.java
+++ b/src/main/java/net/vulkanmod/config/VideoResolution.java
@@ -2,6 +2,7 @@ package net.vulkanmod.config;
 
 import com.mojang.blaze3d.platform.VideoMode;
 import com.mojang.blaze3d.systems.RenderSystem;
+import net.vulkanmod.Initializer;
 import org.apache.commons.lang3.SystemUtils;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWVidMode;
@@ -16,12 +17,13 @@ import static org.lwjgl.glfw.GLFW.*;
 public class VideoResolution {
     private static VideoResolution[] videoResolutions;
     private static final int activePlat = getSupportedPlat();
+    private static final String activeDE=determineDE();
 
     int width;
     int height;
     int refreshRate;
 
-    private List<VideoMode> videoModes;
+    private final List<VideoMode> videoModes;
 
     public VideoResolution(int width, int height) {
         this.width = width;
@@ -57,8 +59,10 @@ public class VideoResolution {
 
     public static void init() {
         RenderSystem.assertOnRenderThread();
-        GLFW.glfwInitHint(GLFW_PLATFORM, activePlat);
-        LOGGER.info("Selecting Platform: "+getStringFromPlat(activePlat));
+        boolean useXwaylandOverride = Initializer.CONFIG.xWayland && isWayLand();
+        int overriddenPlat = useXwaylandOverride ? GLFW_PLATFORM_X11 : activePlat;
+        GLFW.glfwInitHint(GLFW_PLATFORM, overriddenPlat);
+        LOGGER.info("Selecting Platform: " + (useXwaylandOverride ? getStringFromPlat(overriddenPlat) + " (Xwayland Override)" : getStringFromPlat(overriddenPlat) ));
         LOGGER.info("GLFW: "+GLFW.glfwGetVersionString());
         GLFW.glfwInit();
         videoResolutions = populateVideoResolutions(GLFW.glfwGetPrimaryMonitor());
@@ -76,6 +80,13 @@ public class VideoResolution {
             default -> GLFW_ANY_PLATFORM; //Either unknown Platform or Display Server
         };
     }
+
+
+    private static String determineDE() {
+        String xdgSessionDesktop = System.getenv("XDG_SESSION_DESKTOP");
+        return (xdgSessionDesktop != null ? xdgSessionDesktop : "N/A").toLowerCase();
+    }
+
 
     private static int getSupportedPlat() {
         //Switch statement would be ideal, but couldn't find a good way of implementing it, so fell back to basic if statements/branches
@@ -106,6 +117,11 @@ public class VideoResolution {
     public static boolean isWindows() { return activePlat == GLFW_PLATFORM_WIN32; }
     public static boolean isMacOS() { return activePlat == GLFW_PLATFORM_COCOA; }
     public static boolean isAndroid() { return activePlat == GLFW_ANY_PLATFORM; }
+
+    //Desktop Environment Names: https://wiki.archlinux.org/title/Environment_variables_#Examples
+    public static boolean isGNOME(){return activeDE.contains("gnome") || activeDE.contains("GNOME");}
+
+
 
     public static VideoResolution[] getVideoResolutions() {
         return videoResolutions;

--- a/src/main/java/net/vulkanmod/config/VideoResolution.java
+++ b/src/main/java/net/vulkanmod/config/VideoResolution.java
@@ -63,6 +63,7 @@ public class VideoResolution {
         int overriddenPlat = useXwaylandOverride ? GLFW_PLATFORM_X11 : activePlat;
         GLFW.glfwInitHint(GLFW_PLATFORM, overriddenPlat);
         LOGGER.info("Selecting Platform: " + (useXwaylandOverride ? getStringFromPlat(overriddenPlat) + " (Xwayland Override)" : getStringFromPlat(overriddenPlat) ));
+        if(SystemUtils.IS_OS_LINUX) LOGGER.info("Desktop Environment: "+activeDE);
         LOGGER.info("GLFW: "+GLFW.glfwGetVersionString());
         GLFW.glfwInit();
         videoResolutions = populateVideoResolutions(GLFW.glfwGetPrimaryMonitor());
@@ -84,7 +85,10 @@ public class VideoResolution {
 
     private static String determineDE() {
         String xdgSessionDesktop = System.getenv("XDG_SESSION_DESKTOP");
-        return (xdgSessionDesktop != null ? xdgSessionDesktop : "N/A").toLowerCase();
+        String xdgCurrentDesktop = System.getenv("XDG_CURRENT_DESKTOP");
+        if (xdgSessionDesktop != null) return xdgSessionDesktop.toLowerCase();
+        if (xdgCurrentDesktop != null) return xdgCurrentDesktop.toLowerCase();
+        return "N/A";
     }
 
 
@@ -92,7 +96,7 @@ public class VideoResolution {
         //Switch statement would be ideal, but couldn't find a good way of implementing it, so fell back to basic if statements/branches
         if(SystemUtils.IS_OS_WINDOWS) return GLFW_PLATFORM_WIN32;
         if(SystemUtils.IS_OS_MAC_OSX) return GLFW_PLATFORM_COCOA;
-        if(SystemUtils.IS_OS_LINUX) return determineDisplayServer(); //Linux Or Android
+        if(SystemUtils.IS_OS_LINUX) return determineDisplayServer(); //Linux Or Android or Unix based like FreeBSD
 
         return GLFW_ANY_PLATFORM; //Unknown platform
     }
@@ -118,9 +122,10 @@ public class VideoResolution {
     public static boolean isMacOS() { return activePlat == GLFW_PLATFORM_COCOA; }
     public static boolean isAndroid() { return activePlat == GLFW_ANY_PLATFORM; }
 
-    //Desktop Environment Names: https://wiki.archlinux.org/title/Environment_variables_#Examples
+    //Desktop Environment Names: https://wiki.archlinux.org/title/Xdg-utils#Usage
     public static boolean isGnome() { return activeDE.contains("gnome"); }
-
+    public static boolean isWeston() { return activeDE.contains("weston"); }
+    public static boolean isGeneric() { return activeDE.contains("generic"); }
 
 
     public static VideoResolution[] getVideoResolutions() {

--- a/src/main/java/net/vulkanmod/mixin/window/WindowMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/window/WindowMixin.java
@@ -17,7 +17,6 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -70,6 +69,8 @@ public abstract class WindowMixin {
     @Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lorg/lwjgl/glfw/GLFW;glfwCreateWindow(IILjava/lang/CharSequence;JJ)J"))
     private void vulkanHint(WindowEventHandler windowEventHandler, ScreenManager screenManager, DisplayData displayData, String string, String string2, CallbackInfo ci) {
         GLFW.glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+        //Fix Gnome Client-Side Decorators
+        GLFW.glfwWindowHint(GLFW_DECORATED, VideoResolution.isGNOME() && VideoResolution.isWayLand() ? GLFW_FALSE : GLFW_TRUE);
 //        GLFW.glfwWindowHint(GLFW_AUTO_ICONIFY, GLFW_FALSE);
 //        GLFW.glfwWindowHint(GLFW_FOCUSED, GLFW_FALSE);
     }

--- a/src/main/java/net/vulkanmod/mixin/window/WindowMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/window/WindowMixin.java
@@ -70,7 +70,7 @@ public abstract class WindowMixin {
     private void vulkanHint(WindowEventHandler windowEventHandler, ScreenManager screenManager, DisplayData displayData, String string, String string2, CallbackInfo ci) {
         GLFW.glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
         //Fix Gnome Client-Side Decorators
-        GLFW.glfwWindowHint(GLFW_DECORATED, VideoResolution.isGNOME() && VideoResolution.isWayLand() ? GLFW_FALSE : GLFW_TRUE);
+        GLFW.glfwWindowHint(GLFW_DECORATED, VideoResolution.isGnome() && VideoResolution.isWayLand() ? GLFW_FALSE : GLFW_TRUE);
 //        GLFW.glfwWindowHint(GLFW_AUTO_ICONIFY, GLFW_FALSE);
 //        GLFW.glfwWindowHint(GLFW_FOCUSED, GLFW_FALSE);
     }

--- a/src/main/java/net/vulkanmod/mixin/window/WindowMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/window/WindowMixin.java
@@ -70,7 +70,7 @@ public abstract class WindowMixin {
     private void vulkanHint(WindowEventHandler windowEventHandler, ScreenManager screenManager, DisplayData displayData, String string, String string2, CallbackInfo ci) {
         GLFW.glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
         //Fix Gnome Client-Side Decorators
-        GLFW.glfwWindowHint(GLFW_DECORATED, VideoResolution.isGnome() && VideoResolution.isWayLand() ? GLFW_FALSE : GLFW_TRUE);
+        GLFW.glfwWindowHint(GLFW_DECORATED, (VideoResolution.isGnome() | VideoResolution.isWeston() | VideoResolution.isGeneric()) && VideoResolution.isWayLand() ? GLFW_FALSE : GLFW_TRUE);
 //        GLFW.glfwWindowHint(GLFW_AUTO_ICONIFY, GLFW_FALSE);
 //        GLFW.glfwWindowHint(GLFW_FOCUSED, GLFW_FALSE);
     }

--- a/src/main/java/net/vulkanmod/vulkan/framebuffer/SwapChain.java
+++ b/src/main/java/net/vulkanmod/vulkan/framebuffer/SwapChain.java
@@ -361,7 +361,6 @@ public class SwapChain extends Framebuffer {
 
         for(int i = 0;i < availablePresentModes.capacity();i++) {
             if(availablePresentModes.get(i) == requestedMode) {
-                Initializer.LOGGER.info("Using DisplayMode: " + getDisplayModeString(requestedMode));
                 return requestedMode;
             }
         }

--- a/src/main/java/net/vulkanmod/vulkan/framebuffer/SwapChain.java
+++ b/src/main/java/net/vulkanmod/vulkan/framebuffer/SwapChain.java
@@ -31,9 +31,9 @@ public class SwapChain extends Framebuffer {
     private static final int DEFAULT_IMAGE_COUNT = 3;
 
     //Necessary until tearing-control-unstable-v1 is fully implemented on all GPU Drivers for Wayland
-    //(As Immediate Mode (and by extension Screen tearing) doesn't exist on most Wayland installations currently)
+    //(As Immediate Mode (and by extension Screen tearing) doesn't exist on some Wayland installations currently)
     //Try to use Mailbox if possible (in case FreeSync/G-Sync needs it)
-    private static final int defUncappedMode = checkPresentMode(VK_PRESENT_MODE_MAILBOX_KHR, VK_PRESENT_MODE_IMMEDIATE_KHR);
+    private static final int defUncappedMode = checkPresentMode(VK_PRESENT_MODE_IMMEDIATE_KHR, VK_PRESENT_MODE_MAILBOX_KHR);
 
     private RenderPass renderPass;
     private long[] framebuffers;
@@ -354,21 +354,37 @@ public class SwapChain extends Framebuffer {
     }
 
     private int getPresentMode(IntBuffer availablePresentModes) {
-        int requestedMode = vsync ? VK_PRESENT_MODE_FIFO_KHR : defUncappedMode;
+        int requestedMode = vsync ? VK_PRESENT_MODE_FIFO_KHR : Initializer.CONFIG.uncappedMode;
 
-        //fifo mode is the only mode that has to be supported
-        if(requestedMode == VK_PRESENT_MODE_FIFO_KHR)
-            return VK_PRESENT_MODE_FIFO_KHR;
+        //Some Drivers change the supported modes in FullScreen: can't assume any consistency
 
         for(int i = 0;i < availablePresentModes.capacity();i++) {
             if(availablePresentModes.get(i) == requestedMode) {
+                Initializer.LOGGER.info("Using DisplayMode: "+getDisplayModeString(requestedMode));
                 return requestedMode;
             }
         }
+        //update mode in case of platform change
+        //i.e. current uncappedMode conflicts with platform's currently supported mode(s)
+        int fallbackMode = vsync ? VK_PRESENT_MODE_FIFO_KHR : (Initializer.CONFIG.uncappedMode=defUncappedMode);
 
-        Initializer.LOGGER.warn("Requested mode not supported: using fallback VK_PRESENT_MODE_FIFO_KHR");
-        return VK_PRESENT_MODE_FIFO_KHR;
+        //Vsync is applied if both Mailbox+Immediate are not available
+        //This is not a bug and follows the spec, as some platforms only support Vsync
+        //i.e. the spec only Mandates/guarantees FIFO support: everything else + all other modes are optional
 
+        Initializer.LOGGER.warn("Requested mode not supported: using fallback "+ getDisplayModeString(fallbackMode));
+        return fallbackMode;
+
+    }
+
+    private String getDisplayModeString(int requestedMode) {
+        return switch(requestedMode)
+        {
+            case VK_PRESENT_MODE_IMMEDIATE_KHR -> "Immediate";
+            case VK_PRESENT_MODE_MAILBOX_KHR -> "Mailbox (FastSync)";
+            case VK_PRESENT_MODE_FIFO_RELAXED_KHR -> "FIFO Relaxed (Adaptive VSync)";
+            default -> "FIFO (VSync)";
+        };
     }
 
     private static VkExtent2D getExtent(VkSurfaceCapabilitiesKHR capabilities) {
@@ -394,6 +410,31 @@ public class SwapChain extends Framebuffer {
         return actualExtent;
     }
 
+    public static Integer[] checkPresentModes(int... requestedModes) {
+
+        try(MemoryStack stack = stackPush())
+        {
+
+            var a = DeviceManager.querySurfaceProperties(device.getPhysicalDevice(), stack).presentModes;
+            int dModeMask=0;
+            for(int dMode : requestedModes) {
+                for (int i = 0; i < a.capacity(); i++) {
+                    if (a.get(i) == dMode) {
+                        dModeMask|=(1<<dMode);
+                    }
+                }
+            }
+            Integer[] supportedModes = new Integer[Integer.bitCount(dModeMask)];
+            int i=0;
+            for (int mode = 0; mode < 4; mode++) {
+                if ((dModeMask & (1 << mode)) != 0) {
+                    supportedModes[i++] = mode;
+                }
+            }
+
+            return supportedModes; //If None of the request modes exist/are supported by Driver
+        }
+    }
     private static int checkPresentMode(int... requestedModes) {
         try(MemoryStack stack = MemoryStack.stackPush())
         {


### PR DESCRIPTION
#### Gnome CSD Workarounds:
* Disable the window decorators only if both Gnome and Wayland are present
* This fix is exclusive to Gnome on Wayland, has no effect on Xwayland, X11 or any other DE.

#### Xwayland Override: 
* Adds an Xwayland config option: 
* Is config file only to avoid cluttering the options menu

 #### Tear control: 
* Adds a screen tearing toggle, which exposes Immediate Mode on all platforms if supported by driver
* Added in preparation for the `tearing-control-unstable-v1` protocol, which is becoming more well supported
   * _(As it was very poorly supported when Wayland support was added in 0.3.6)_
* Defaults back to Mailbox/FastSync if `tearing-control-unstable-v1` is unavailable
* Available modes can't be guaranteed and depend on Driver: 
    * Some drivers only support MailBox **OR** Immediate, not both