### PR TITLE
[GPU Optimization/Performance] Attachment color clear skip

### DIFF
--- a/src/main/java/net/vulkanmod/vulkan/pass/DefaultMainPass.java
+++ b/src/main/java/net/vulkanmod/vulkan/pass/DefaultMainPass.java
@@ -39,8 +39,8 @@ public class DefaultMainPass implements MainPass {
     private void createRenderPasses() {
         RenderPass.Builder builder = RenderPass.builder(this.mainFramebuffer);
         builder.getColorAttachmentInfo().setFinalLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
-        builder.getColorAttachmentInfo().setOps(VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_STORE);
-        builder.getDepthAttachmentInfo().setOps(VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_STORE);
+        builder.getColorAttachmentInfo().setOps(VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_STORE_OP_STORE);
+        builder.getDepthAttachmentInfo().setOps(VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_STORE_OP_STORE);
 
         this.mainRenderPass = builder.build();
 


### PR DESCRIPTION
_(Based on this older PR: https://github.com/xCollateral/VulkanMod/pull/359, but with alot of the outdated/unnecessary code removed)_

A small optimization patch which automatically skips color attachment clears if the color is the same, decreasing the rate of full screen clears per frame

This helps to avoid unnecessary stalls in the GPU and improves performance slightly in game, especially at high framerates