### PR TITLE
[GPU optimizations] Reduce attachment clears

### DIFF
--- a/src/main/java/net/vulkanmod/mixin/MixinPlugin.java
+++ b/src/main/java/net/vulkanmod/mixin/MixinPlugin.java
@@ -1,5 +1,7 @@
 package net.vulkanmod.mixin;
 
+import net.fabricmc.loader.api.FabricLoader;
+import net.vulkanmod.Initializer;
 import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
@@ -8,6 +10,8 @@ import java.util.List;
 import java.util.Set;
 
 public class MixinPlugin implements IMixinConfigPlugin {
+
+    private static final boolean hasJourneyMap = FabricLoader.getInstance().isModLoaded("journeymap");
 
     @Override
     public void onLoad(String mixinPackage) {
@@ -20,6 +24,9 @@ public class MixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if(hasJourneyMap && mixinClassName.equals("net.vulkanmod.mixin.render.LevelRendererMixin")) {
+            return false;
+        }
         return true;
     }
 

--- a/src/main/java/net/vulkanmod/mixin/render/LevelRendererMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/render/LevelRendererMixin.java
@@ -12,6 +12,7 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.io.IOException;
@@ -26,6 +27,14 @@ public abstract class LevelRendererMixin {
     @Shadow @Nullable private RenderTarget entityTarget;
 
     @Shadow @Final private static Logger LOGGER;
+
+
+    @Redirect(method = "renderLevel", at=@At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;clear(IZ)V"))
+    private void removeClear(int i, boolean bl) {}
+
+    @Redirect(method = "renderLevel", at=@At(value = "INVOKE", target = "Lcom/mojang/blaze3d/pipeline/RenderTarget;clear(Z)V"))
+    private void removeClear2(RenderTarget instance, boolean bl) {}
+
 
 //    /**
 //     * @author

--- a/src/main/java/net/vulkanmod/mixin/render/MinecraftMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/render/MinecraftMixin.java
@@ -49,7 +49,8 @@ public class MinecraftMixin {
     //Main target (framebuffer) ops
     @Redirect(method = "runTick", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;clear(IZ)V"))
     private void beginRender(int i, boolean bl) {
-        RenderSystem.clear(i, bl);
+        //Manual Clear replaced with Load Op clear: According to the spec Load Op Clear can be faster than Attachment Clears
+        //RenderSystem.clear(i, bl);
         Renderer.getInstance().beginFrame();
     }
 

--- a/src/main/java/net/vulkanmod/vulkan/pass/DefaultMainPass.java
+++ b/src/main/java/net/vulkanmod/vulkan/pass/DefaultMainPass.java
@@ -1,6 +1,7 @@
 package net.vulkanmod.vulkan.pass;
 
 import com.mojang.blaze3d.pipeline.RenderTarget;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.Minecraft;
 import net.vulkanmod.vulkan.Renderer;
 import net.vulkanmod.vulkan.Vulkan;
@@ -37,10 +38,15 @@ public class DefaultMainPass implements MainPass {
     }
 
     private void createRenderPasses() {
+
+        final boolean hasJourneyMap = FabricLoader.getInstance().isModLoaded("journeymap");
+        final int vkAttachmentLoadOpClear = hasJourneyMap ? VK_ATTACHMENT_LOAD_OP_DONT_CARE : VK_ATTACHMENT_LOAD_OP_CLEAR;
+        //Restore Default LoadOp behaviour if journeymap is present
+
         RenderPass.Builder builder = RenderPass.builder(this.mainFramebuffer);
         builder.getColorAttachmentInfo().setFinalLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
-        builder.getColorAttachmentInfo().setOps(VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_STORE);
-        builder.getDepthAttachmentInfo().setOps(VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_STORE);
+        builder.getColorAttachmentInfo().setOps(vkAttachmentLoadOpClear, VK_ATTACHMENT_STORE_OP_STORE);
+        builder.getDepthAttachmentInfo().setOps(vkAttachmentLoadOpClear, VK_ATTACHMENT_STORE_OP_STORE);
 
         this.mainRenderPass = builder.build();
 


### PR DESCRIPTION
_(Greatly improved version of https://github.com/xCollateral/VulkanMod/pull/465)_

A small optimization patch which removes almost all attachment clears used each frame

This helps to avoid unnecessary stalls in the GPU and improves performance slightly in game, especially at high framerates

_(If Journeymap is present, these optimizations are disabled to avoid visual glitches)_