### PR TITLE
[Samplers] Patch: Simplify + Optimize Sampler Management

### DIFF
--- a/src/main/java/net/vulkanmod/gl/GlRenderbuffer.java
+++ b/src/main/java/net/vulkanmod/gl/GlRenderbuffer.java
@@ -168,7 +168,7 @@ public class GlRenderbuffer {
             default -> 0;
         };
 
-        vulkanImage.updateTextureSampler(maxLod, samplerFlags);
+        vulkanImage.updateTextureSampler(samplerFlags);
     }
 
     private void uploadImage(ByteBuffer pixels) {

--- a/src/main/java/net/vulkanmod/gl/GlTexture.java
+++ b/src/main/java/net/vulkanmod/gl/GlTexture.java
@@ -225,7 +225,7 @@ public class GlTexture {
             default -> 0;
         };
 
-        vulkanImage.updateTextureSampler(maxLod, samplerFlags);
+        vulkanImage.updateTextureSampler(samplerFlags);
     }
 
     private void uploadImage(ByteBuffer pixels) {

--- a/src/main/java/net/vulkanmod/gl/GlTexture.java
+++ b/src/main/java/net/vulkanmod/gl/GlTexture.java
@@ -111,7 +111,7 @@ public class GlTexture {
 
         switch (pName) {
             case GL30.GL_TEXTURE_MAX_LEVEL -> boundTexture.setMaxLevel(param);
-            case GL30.GL_TEXTURE_MAX_LOD -> boundTexture.setMaxLod(param);
+            case GL30.GL_TEXTURE_MAX_LOD -> {}
             case GL30.GL_TEXTURE_MIN_LOD -> {}
             case GL30.GL_TEXTURE_LOD_BIAS -> {}
 
@@ -170,7 +170,6 @@ public class GlTexture {
 
     boolean needsUpdate = false;
     int maxLevel = 0;
-    int maxLod = 0;
     int minFilter, magFilter = GL11.GL_LINEAR;
 
     boolean clamp = true;
@@ -253,16 +252,6 @@ public class GlTexture {
         if (maxLevel != l) {
             maxLevel = l;
             needsUpdate = true;
-        }
-    }
-
-    void setMaxLod(int l) {
-        if (l < 0)
-            throw new IllegalStateException("max level cannot be < 0.");
-
-        if (maxLod != l) {
-            maxLod = l;
-            updateSampler();
         }
     }
 

--- a/src/main/java/net/vulkanmod/vulkan/Renderer.java
+++ b/src/main/java/net/vulkanmod/vulkan/Renderer.java
@@ -21,6 +21,7 @@ import net.vulkanmod.vulkan.shader.Pipeline;
 import net.vulkanmod.vulkan.shader.PipelineState;
 import net.vulkanmod.vulkan.shader.Uniforms;
 import net.vulkanmod.vulkan.shader.layout.PushConstants;
+import net.vulkanmod.vulkan.texture.SamplerManager;
 import net.vulkanmod.vulkan.texture.VTextureSelector;
 import net.vulkanmod.vulkan.util.VUtil;
 import net.vulkanmod.vulkan.util.VkResult;
@@ -462,6 +463,8 @@ public class Renderer {
 
         PipelineManager.destroyPipelines();
         VTextureSelector.getWhiteTexture().free();
+        SamplerManager.cleanUp();
+
     }
 
     private void destroySyncObjects() {

--- a/src/main/java/net/vulkanmod/vulkan/texture/SamplerManager.java
+++ b/src/main/java/net/vulkanmod/vulkan/texture/SamplerManager.java
@@ -21,19 +21,18 @@ public abstract class SamplerManager {
 
     static final Short2LongMap SAMPLERS = new Short2LongOpenHashMap();
 
-    public static long getTextureSampler(byte maxLod, byte flags) {
-        short key = (short) (flags | (maxLod << 8));
-        long sampler = SAMPLERS.getOrDefault(key, 0L);
+    public static long getTextureSampler(byte flags) {
+        long sampler = SAMPLERS.getOrDefault(flags, 0L);
 
         if (sampler == 0L) {
-            sampler = createTextureSampler(maxLod, flags);
-            SAMPLERS.put(key, sampler);
+            sampler = createTextureSampler(flags);
+            SAMPLERS.put(flags, sampler);
         }
 
         return sampler;
     }
 
-    private static long createTextureSampler(byte maxLod, byte flags) {
+    private static long createTextureSampler(byte flags) {
         Validate.isTrue(
                 (flags & (REDUCTION_MIN_BIT | REDUCTION_MAX_BIT)) != (REDUCTION_MIN_BIT | REDUCTION_MAX_BIT)
         );
@@ -78,7 +77,7 @@ public abstract class SamplerManager {
                 } else {
                     samplerInfo.mipmapMode(VK_SAMPLER_MIPMAP_MODE_NEAREST);
                 }
-                samplerInfo.maxLod(maxLod);
+                samplerInfo.maxLod(VK_LOD_CLAMP_NONE);
                 samplerInfo.minLod(0.0F);
                 samplerInfo.mipLodBias(MIP_BIAS);
             }

--- a/src/main/java/net/vulkanmod/vulkan/texture/VulkanImage.java
+++ b/src/main/java/net/vulkanmod/vulkan/texture/VulkanImage.java
@@ -59,7 +59,7 @@ public class VulkanImage {
         this.usage = usage;
         this.aspect = getAspect(this.format);
 
-        this.sampler = SamplerManager.getTextureSampler((byte) this.mipLevels, (byte) 0);
+        this.sampler = SamplerManager.getTextureSampler((byte) 0);
     }
 
     private VulkanImage(Builder builder) {
@@ -78,7 +78,7 @@ public class VulkanImage {
         image.createImage(builder.mipLevels, builder.width, builder.height, builder.format, builder.usage);
         image.mainImageView = createImageView(image.id, builder.format, image.aspect, builder.mipLevels);
 
-        image.sampler = SamplerManager.getTextureSampler(builder.mipLevels, builder.samplerFlags);
+        image.sampler = SamplerManager.getTextureSampler(builder.samplerFlags);
 
         if (builder.levelViews) {
             image.levelImageViews = new long[builder.mipLevels];
@@ -242,11 +242,7 @@ public class VulkanImage {
     }
 
     public void updateTextureSampler(byte flags) {
-        updateTextureSampler(this.mipLevels - 1, flags);
-    }
-
-    public void updateTextureSampler(int maxLod, byte flags) {
-        this.sampler = SamplerManager.getTextureSampler((byte) maxLod, flags);
+        this.sampler = SamplerManager.getTextureSampler(flags);
     }
 
     public void transitionImageLayout(MemoryStack stack, VkCommandBuffer commandBuffer, int newLayout) {


### PR DESCRIPTION
Simplifies sampler management by using the special hardware constant `VK_LOD_CLAMP_NONE`

`VK_LOD_CLAMP_NONE` permits the sampler to use all available miplevels on the texture, allowing one Sampler to handle all possible mipmap levels, with the additional effect of removing the need to track maxLods for each respective sampler.

Potentially may give a slight performance improvement on some hardware as a result of the reduced sampler count