### PR TITLE
[Performance] Add Early-Z optimization option (Experimental Fast Leaves)

### DIFF
--- a/src/main/java/net/vulkanmod/config/Config.java
+++ b/src/main/java/net/vulkanmod/config/Config.java
@@ -21,7 +21,7 @@ public class Config {
     public int advCulling = 2;
     public boolean indirectDraw = false;
 
-    public boolean uniqueOpaqueLayer = true;
+    public boolean earlyZ = false;
     public boolean entityCulling = true;
     public int device = -1;
 

--- a/src/main/java/net/vulkanmod/config/option/Options.java
+++ b/src/main/java/net/vulkanmod/config/option/Options.java
@@ -2,6 +2,7 @@ package net.vulkanmod.config.option;
 
 import com.mojang.blaze3d.platform.Window;
 import net.minecraft.client.*;
+import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.network.chat.Component;
 import net.vulkanmod.Initializer;
 import net.vulkanmod.config.Config;
@@ -249,13 +250,14 @@ public abstract class Options {
                                 value -> config.entityCulling = value,
                                 () -> config.entityCulling)
                                 .setTooltip(Component.translatable("vulkanmod.options.entityCulling.tooltip")),
-                        new SwitchOption(Component.translatable("vulkanmod.options.uniqueOpaqueLayer"),
+                        new SwitchOption(Component.translatable("vulkanmod.options.earlyZ"),
                                 value -> {
-                                    config.uniqueOpaqueLayer = value;
+                                    config.earlyZ = value;
+//                                    ItemBlockRenderTypes.setFancy(!value);
                                     minecraft.levelRenderer.allChanged();
                                 },
-                                () -> config.uniqueOpaqueLayer)
-                                .setTooltip(Component.translatable("vulkanmod.options.uniqueOpaqueLayer.tooltip")),
+                                () -> config.earlyZ)
+                                .setTooltip(Component.translatable("vulkanmod.options.earlyZ.tooltip")),
                         new SwitchOption(Component.translatable("vulkanmod.options.indirectDraw"),
                                 value -> config.indirectDraw = value,
                                 () -> config.indirectDraw)

--- a/src/main/java/net/vulkanmod/render/PipelineManager.java
+++ b/src/main/java/net/vulkanmod/render/PipelineManager.java
@@ -2,6 +2,7 @@ package net.vulkanmod.render;
 
 import com.mojang.blaze3d.vertex.VertexFormat;
 import net.minecraft.client.renderer.RenderType;
+import net.vulkanmod.Initializer;
 import net.vulkanmod.render.chunk.build.thread.ThreadBuilderPack;
 import net.vulkanmod.render.vertex.CustomVertexFormat;
 import net.vulkanmod.render.vertex.TerrainRenderType;
@@ -33,7 +34,11 @@ public abstract class PipelineManager {
     }
 
     public static void setDefaultShader() {
-        setShaderGetter(renderType -> renderType == TerrainRenderType.TRANSLUCENT ? terrainShaderEarlyZ : terrainShader);
+        setShaderGetter(renderType -> switch (renderType) {
+            case SOLID, TRANSLUCENT, TRIPWIRE -> terrainShaderEarlyZ;
+            case CUTOUT_MIPPED -> Initializer.CONFIG.earlyZ ? terrainShaderEarlyZ : terrainShader;
+            case CUTOUT -> terrainShader;
+        });
     }
 
     private static void createBasicPipelines() {

--- a/src/main/java/net/vulkanmod/render/chunk/build/task/BuildTask.java
+++ b/src/main/java/net/vulkanmod/render/chunk/build/task/BuildTask.java
@@ -173,15 +173,15 @@ public class BuildTask extends ChunkTask {
     }
 
     private TerrainRenderType compactRenderTypes(TerrainRenderType renderType) {
-        if (Initializer.CONFIG.uniqueOpaqueLayer) {
+        if (Initializer.CONFIG.earlyZ) {
             renderType = switch (renderType) {
-                case SOLID, CUTOUT, CUTOUT_MIPPED -> TerrainRenderType.CUTOUT_MIPPED;
+                case SOLID, CUTOUT_MIPPED -> TerrainRenderType.CUTOUT_MIPPED;
+                case CUTOUT -> TerrainRenderType.CUTOUT;
                 case TRANSLUCENT, TRIPWIRE -> TerrainRenderType.TRANSLUCENT;
             };
         } else {
             renderType = switch (renderType) {
-                case SOLID, CUTOUT_MIPPED -> TerrainRenderType.CUTOUT_MIPPED;
-                case CUTOUT -> TerrainRenderType.CUTOUT;
+                case SOLID, CUTOUT, CUTOUT_MIPPED -> TerrainRenderType.CUTOUT_MIPPED;
                 case TRANSLUCENT, TRIPWIRE -> TerrainRenderType.TRANSLUCENT;
             };
         }

--- a/src/main/java/net/vulkanmod/vulkan/shader/PipelineState.java
+++ b/src/main/java/net/vulkanmod/vulkan/shader/PipelineState.java
@@ -379,6 +379,7 @@ public class PipelineState {
                 case 516 -> VK_COMPARE_OP_GREATER;
                 case 518 -> VK_COMPARE_OP_GREATER_OR_EQUAL;
                 case 514 -> VK_COMPARE_OP_EQUAL;
+                case 513 -> VK_COMPARE_OP_LESS;
                 default -> throw new RuntimeException("unknown blend factor..");
 
 //                case 515 -> VK_COMPARE_OP_GREATER_OR_EQUAL;

--- a/src/main/resources/assets/vulkanmod/lang/en_us.json
+++ b/src/main/resources/assets/vulkanmod/lang/en_us.json
@@ -33,8 +33,8 @@
 
   "vulkanmod.options.refreshRate": "Refresh Rate",
 
-  "vulkanmod.options.uniqueOpaqueLayer": "Unique opaque layer",
-  "vulkanmod.options.uniqueOpaqueLayer.tooltip": "Use a unique render layer for opaque terrain to improve performance.",
+  "vulkanmod.options.earlyZ": "Early-Z (Fast Leaves)",
+  "vulkanmod.options.earlyZ.tooltip": "Enables Early-Z culling: (Experimental version of Vanilla's Fast leaves)\nHas the drawback of increased drawcalls, may be slower on some hardware",
 
   "vulkanmod.options.windowedFullscreen": "Windowed Fullscreen"
 }


### PR DESCRIPTION
Replaces the Unique Opaque Layer optimization with an experimental Early-Z option

Early-Z is a special shader optimization that culls geometry rendered behind other blocks, which has the side effect of restoring the ability to use fast leaves in VulkanMod