### PR TITLE
Fix polygon mode mixin using face as mode

### DIFF
--- a/src/main/java/net/vulkanmod/mixin/render/RenderSystemMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/render/RenderSystemMixin.java
@@ -291,9 +291,9 @@ public abstract class RenderSystemMixin {
      * @author
      */
     @Overwrite(remap = false)
-    public static void polygonMode(final int i, final int j) {
+    public static void polygonMode(final int face, final int mode) {
         assertOnRenderThread();
-        VRenderSystem.setPolygonModeGL(i);
+        VRenderSystem.setPolygonModeGL(mode);
     }
 
     /**


### PR DESCRIPTION
Fix compatibility issue with Not-Enough-Crashes, see:
- https://github.com/natanfudge/Not-Enough-Crashes/blob/1.21/common/src/main/java/fudge/notenoughcrashes/utils/GlUtil.java#L39
- https://registry.khronos.org/OpenGL-Refpages/gl4/html/glPolygonMode.xhtml
