### PR TITLE
Fix sound playing when range option slider is not being dragged.

### DIFF
--- a/src/main/java/net/vulkanmod/config/gui/widget/RangeOptionWidget.java
+++ b/src/main/java/net/vulkanmod/config/gui/widget/RangeOptionWidget.java
@@ -15,6 +15,7 @@ public class RangeOptionWidget extends OptionWidget<RangeOption> {
     protected double value;
 
     private boolean focused;
+    private boolean dragging;
 
     public RangeOptionWidget(RangeOption option, int x, int y, int width, int height, Component name) {
         super(x, y, width, height, name);
@@ -107,6 +108,7 @@ public class RangeOptionWidget extends OptionWidget<RangeOption> {
 
     @Override
     protected void onDrag(double mouseX, double mouseY, double deltaX, double deltaY) {
+        dragging = true;
         this.setValueFromMouse(mouseX);
     }
 
@@ -121,8 +123,9 @@ public class RangeOptionWidget extends OptionWidget<RangeOption> {
 
     @Override
     public void onRelease(double mouseX, double mouseY) {
-        if (this.controlHovered) {
+        if (this.controlHovered && dragging) {
             super.playDownSound(Minecraft.getInstance().getSoundManager());
         }
+        dragging = false;
     }
 }


### PR DESCRIPTION
 * RangeOptionWidget's Global Variables:
    * Introduced variable **dragging** to track the drag state internal in RangeOptionWidget.

* RangeOptionWidget's onDrag(double mouseX, double mouseY, double deltaX, double deltaY):
    * Sets **dragging** to true when a drag operation starts.

 * RangeOptionWidget's onRelease(double mouseX, double mouseY):
    * Checks if the slider was being **dragged** before playing the sound.
    * Resets **dragging** to false when the mouse is released.

This modification ensures that the sound played when the mouse is released, is only played if the mouse was previously **dragging** the slider.