### PR TITLE
Some compatibility fixes

### DIFF
--- a/src/main/java/net/vulkanmod/render/chunk/buffer/DrawBuffers.java
+++ b/src/main/java/net/vulkanmod/render/chunk/buffer/DrawBuffers.java
@@ -365,7 +365,10 @@ public class DrawBuffers {
     public void bindBuffers(VkCommandBuffer commandBuffer, Pipeline pipeline, TerrainRenderType terrainRenderType, double camX, double camY, double camZ) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
             var vertexBuffer = getAreaBuffer(terrainRenderType);
-            nvkCmdBindVertexBuffers(commandBuffer, 0, 1, stack.npointer(vertexBuffer.getId()), stack.npointer(0));
+            // VkBuffer is either a 64-bit unsigned integer or a 64-bit pointer, and
+            // VkDeviceSize is always an uint64_t. Both are equivalent to a Java "long",
+            // so use "stack.nlong" here.
+            nvkCmdBindVertexBuffers(commandBuffer, 0, 1, stack.nlong(vertexBuffer.getId()), stack.nlong(0));
             updateChunkAreaOrigin(commandBuffer, pipeline, camX, camY, camZ, stack);
         }
 

--- a/src/main/java/net/vulkanmod/vulkan/framebuffer/SwapChain.java
+++ b/src/main/java/net/vulkanmod/vulkan/framebuffer/SwapChain.java
@@ -121,7 +121,19 @@ public class SwapChain extends Framebuffer {
             }
 
             createInfo.preTransform(surfaceProperties.capabilities.currentTransform());
-            createInfo.compositeAlpha(VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR);
+
+            int supportedCompositeAlpha = surfaceProperties.capabilities.supportedCompositeAlpha();
+            if((supportedCompositeAlpha & VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR) != 0) {
+                createInfo.compositeAlpha(VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR);
+            }else if((supportedCompositeAlpha & VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR) != 0){
+                // PowerVR GE8320 Vulkan drivers don't support the alpha composite opaque bit.
+                // In that case, use the inherit mode if supported.
+                createInfo.compositeAlpha(VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR);
+            } else {
+                // Not sure how to handle the other cases, to be honest...
+                throw new RuntimeException("Neither opaque, nor inherited alpha compositing modes are supported.");
+            }
+
             createInfo.presentMode(presentMode);
             createInfo.clipped(true);
 


### PR DESCRIPTION
- Fixes an issue with vkCmdBindVertexBuffers caused by incorrect usage of MemoryStack functions.
(Old code used stack.npointer(), size of which is architecture-dependent, while the handle types are always uint64_t or 64-bit pointer types.)
- Fixes a validation error when creating swapchain if the VK_COMPOSITE_ALPHA_OPAQUE_BIT isn't supported by the driver.