### PR TITLE
Fix Entity Distance 0 value when below 100

### DIFF
--- a/src/main/java/net/vulkanmod/config/option/Options.java
+++ b/src/main/java/net/vulkanmod/config/option/Options.java
@@ -217,8 +217,8 @@ public abstract class Options {
                                 () -> minecraftOptions.entityShadows().get()),
                         new RangeOption(Component.translatable("options.entityDistanceScaling"),
                                 50, 500, 25,
-                                value -> minecraftOptions.entityDistanceScaling().set(value * 0.01),
-                                () -> minecraftOptions.entityDistanceScaling().get().intValue() * 100),
+                                value -> minecraftOptions.entityDistanceScaling().set(value / 100.0),
+                                () -> (int)(minecraftOptions.entityDistanceScaling().get() * 100)),
                         new CyclingOption<>(Component.translatable("options.mipmapLevels"),
                                 new Integer[]{0, 1, 2, 3, 4},
                                 value -> {


### PR DESCRIPTION
This will fix a minor bug with Entity Distance options with VulkanMod!

### Before Fix
![2025-05-25_11 58 13](https://github.com/user-attachments/assets/c7f96bae-22a5-4069-99f6-d23538624ff8)

### After Fix
![2025-05-25_12 02 37](https://github.com/user-attachments/assets/a2c55634-3a13-4770-8da9-1e9d4023baea)