### PR TITLE
Monitor switcher

### DIFF
--- a/src/main/java/net/vulkanmod/config/Config.java
+++ b/src/main/java/net/vulkanmod/config/Config.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 public class Config {
     public VideoModeSet.VideoMode videoMode = VideoModeManager.getFirstAvailable().getVideoMode();
     public int windowMode = 0;
+    public String monitor = "";
 
     public int advCulling = 2;
     public boolean indirectDraw = true;

--- a/src/main/java/net/vulkanmod/config/Config.java
+++ b/src/main/java/net/vulkanmod/config/Config.java
@@ -15,7 +15,7 @@ import java.util.Collections;
 public class Config {
     public VideoModeSet.VideoMode videoMode = VideoModeManager.getFirstAvailable().getVideoMode();
     public int windowMode = 0;
-    public String monitor = "";
+    public String monitor = ""; // monitor is a pointer and can't be resued so name is used instead
 
     public int advCulling = 2;
     public boolean indirectDraw = true;

--- a/src/main/java/net/vulkanmod/config/Config.java
+++ b/src/main/java/net/vulkanmod/config/Config.java
@@ -15,7 +15,7 @@ import java.util.Collections;
 public class Config {
     public VideoModeSet.VideoMode videoMode = VideoModeManager.getFirstAvailable().getVideoMode();
     public int windowMode = 0;
-    public String monitor = ""; // monitor is a pointer and can't be resued so name is used instead
+    public String monitor = ""; // monitor is a pointer and can't be reused so name is used instead
 
     public int advCulling = 2;
     public boolean indirectDraw = true;

--- a/src/main/java/net/vulkanmod/config/option/Options.java
+++ b/src/main/java/net/vulkanmod/config/option/Options.java
@@ -15,6 +15,8 @@ import net.vulkanmod.render.vertex.TerrainRenderType;
 import net.vulkanmod.vulkan.Renderer;
 import net.vulkanmod.vulkan.device.DeviceManager;
 
+import static org.lwjgl.glfw.GLFW.glfwGetMonitorName;
+
 import java.util.stream.IntStream;
 
 public abstract class Options {
@@ -35,6 +37,15 @@ public abstract class Options {
 
         VideoModeManager.selectedVideoMode = videoMode;
         var refreshRates = videoModeSet.getRefreshRates();
+
+        CyclingOption<Long> monitorOption = (CyclingOption<Long>) new CyclingOption<Long>(
+                Component.translatable("vulkanmod.options.monitor"),
+                VideoModeManager.getMonitors(),
+                (value) -> {
+                    VideoModeManager.selectedMonitor = value;
+                },
+                () -> VideoModeManager.selectedMonitor
+        ).setTranslator(monitor_address -> Component.nullToEmpty(glfwGetMonitorName(monitor_address)));
 
         CyclingOption<Integer> RefreshRate = (CyclingOption<Integer>) new CyclingOption<>(
                 Component.translatable("vulkanmod.options.refreshRate"),
@@ -77,6 +88,7 @@ public abstract class Options {
 
         return new OptionBlock[]{
                 new OptionBlock("", new Option<?>[]{
+                        monitorOption,
                         resolutionOption,
                         RefreshRate,
                         new CyclingOption<>(Component.translatable("vulkanmod.options.windowMode"),

--- a/src/main/java/net/vulkanmod/config/option/Options.java
+++ b/src/main/java/net/vulkanmod/config/option/Options.java
@@ -16,7 +16,6 @@ import net.vulkanmod.vulkan.Renderer;
 import net.vulkanmod.vulkan.device.DeviceManager;
 
 import static org.lwjgl.glfw.GLFW.glfwGetMonitorName;
-import static org.lwjgl.glfw.GLFW.glfwSetWindowMonitor;
 
 import java.util.stream.IntStream;
 

--- a/src/main/java/net/vulkanmod/config/option/Options.java
+++ b/src/main/java/net/vulkanmod/config/option/Options.java
@@ -16,6 +16,7 @@ import net.vulkanmod.vulkan.Renderer;
 import net.vulkanmod.vulkan.device.DeviceManager;
 
 import static org.lwjgl.glfw.GLFW.glfwGetMonitorName;
+import static org.lwjgl.glfw.GLFW.glfwSetWindowMonitor;
 
 import java.util.stream.IntStream;
 
@@ -38,11 +39,14 @@ public abstract class Options {
         VideoModeManager.selectedVideoMode = videoMode;
         var refreshRates = videoModeSet.getRefreshRates();
 
-        CyclingOption<Long> monitorOption = (CyclingOption<Long>) new CyclingOption<Long>(
+        CyclingOption<Long> monitorOption = (CyclingOption<Long>) new CyclingOption<>(
                 Component.translatable("vulkanmod.options.monitor"),
                 VideoModeManager.getMonitors(),
                 (value) -> {
                     VideoModeManager.selectedMonitor = value;
+
+                    if (minecraftOptions.fullscreen().get())
+                        fullscreenDirty = true;
                 },
                 () -> VideoModeManager.selectedMonitor
         ).setTranslator(monitor_address -> Component.nullToEmpty(glfwGetMonitorName(monitor_address)));

--- a/src/main/java/net/vulkanmod/config/option/Options.java
+++ b/src/main/java/net/vulkanmod/config/option/Options.java
@@ -83,6 +83,8 @@ public abstract class Options {
                 VideoModeManager.getMonitors(),
                 (value) -> {
                     VideoModeManager.setSelectedMonitor(value);
+                    VideoModeManager.applySelectedMonitor();
+                    VideoModeManager.applySelectedVideoMode();
 
                     if (minecraftOptions.fullscreen().get())
                         fullscreenDirty = true;

--- a/src/main/java/net/vulkanmod/config/option/Options.java
+++ b/src/main/java/net/vulkanmod/config/option/Options.java
@@ -39,18 +39,6 @@ public abstract class Options {
         VideoModeManager.selectedVideoMode = videoMode;
         var refreshRates = videoModeSet.getRefreshRates();
 
-        CyclingOption<Long> monitorOption = (CyclingOption<Long>) new CyclingOption<>(
-                Component.translatable("vulkanmod.options.monitor"),
-                VideoModeManager.getMonitors(),
-                (value) -> {
-                    VideoModeManager.selectedMonitor = value;
-
-                    if (minecraftOptions.fullscreen().get())
-                        fullscreenDirty = true;
-                },
-                () -> VideoModeManager.selectedMonitor
-        ).setTranslator(monitor_address -> Component.nullToEmpty(glfwGetMonitorName(monitor_address)));
-
         CyclingOption<Integer> RefreshRate = (CyclingOption<Integer>) new CyclingOption<>(
                 Component.translatable("vulkanmod.options.refreshRate"),
                 refreshRates.toArray(new Integer[0]),
@@ -64,7 +52,7 @@ public abstract class Options {
                 () -> VideoModeManager.selectedVideoMode.refreshRate)
                 .setTranslator(refreshRate -> Component.nullToEmpty(refreshRate.toString()));
 
-        Option<VideoModeSet> resolutionOption = new CyclingOption<>(
+        CyclingOption<VideoModeSet> resolutionOption = (CyclingOption<VideoModeSet>) new CyclingOption<>(
                 Component.translatable("options.fullscreen.resolution"),
                 VideoModeManager.getVideoResolutions(),
                 (value) -> {
@@ -89,6 +77,21 @@ public abstract class Options {
             RefreshRate.setValues(newRefreshRates);
             RefreshRate.setNewValue(newRefreshRates[newRefreshRates.length - 1]);
         });
+
+        CyclingOption<Long> monitorOption = (CyclingOption<Long>) new CyclingOption<>(
+                Component.translatable("vulkanmod.options.monitor"),
+                VideoModeManager.getMonitors(),
+                (value) -> {
+                    VideoModeManager.setSelectedMonitor(value);
+
+                    if (minecraftOptions.fullscreen().get())
+                        fullscreenDirty = true;
+
+                    resolutionOption.setValues(VideoModeManager.getVideoResolutions());
+                    resolutionOption.setNewValue(VideoModeManager.getFirstAvailable());
+                },
+                VideoModeManager::getSelectedMonitor
+        ).setTranslator(monitor_address -> Component.nullToEmpty(glfwGetMonitorName(monitor_address)));
 
         return new OptionBlock[]{
                 new OptionBlock("", new Option<?>[]{

--- a/src/main/java/net/vulkanmod/config/video/VideoModeManager.java
+++ b/src/main/java/net/vulkanmod/config/video/VideoModeManager.java
@@ -14,14 +14,13 @@ public abstract class VideoModeManager {
     private static VideoModeSet.VideoMode osVideoMode;
     private static VideoModeSet[] videoModeSets;
 
-    public static long selectedMonitor;
+    private static long selectedMonitor;
     public static VideoModeSet.VideoMode selectedVideoMode;
 
     public static void init() {
-        selectedMonitor = glfwGetPrimaryMonitor();
         monitors = populateMonitors();
-        osVideoMode = getCurrentVideoMode(selectedMonitor);
-        videoModeSets = populateVideoResolutions(selectedMonitor);
+        setSelectedMonitor(glfwGetPrimaryMonitor());
+
     }
 
     public static void applySelectedVideoMode() {
@@ -114,5 +113,16 @@ public abstract class VideoModeManager {
 
     public static Long[] getMonitors(){
         return monitors;
+    }
+
+    public static long getSelectedMonitor() {
+        return selectedMonitor;
+    }
+
+    public static void setSelectedMonitor(long new_monitor){
+        selectedMonitor = new_monitor;
+        osVideoMode = getCurrentVideoMode(selectedMonitor);
+        videoModeSets = populateVideoResolutions(selectedMonitor);
+        selectedVideoMode = getFirstAvailable().getVideoMode();
     }
 }

--- a/src/main/java/net/vulkanmod/config/video/VideoModeManager.java
+++ b/src/main/java/net/vulkanmod/config/video/VideoModeManager.java
@@ -10,15 +10,18 @@ import java.util.List;
 import static org.lwjgl.glfw.GLFW.*;
 
 public abstract class VideoModeManager {
+    private static Long[] monitors;
     private static VideoModeSet.VideoMode osVideoMode;
     private static VideoModeSet[] videoModeSets;
 
+    public static long selectedMonitor;
     public static VideoModeSet.VideoMode selectedVideoMode;
 
     public static void init() {
-        long monitor = glfwGetPrimaryMonitor();
-        osVideoMode = getCurrentVideoMode(monitor);
-        videoModeSets = populateVideoResolutions(GLFW.glfwGetPrimaryMonitor());
+        selectedMonitor = glfwGetPrimaryMonitor();
+        monitors = populateMonitors();
+        osVideoMode = getCurrentVideoMode(selectedMonitor);
+        videoModeSets = populateVideoResolutions(selectedMonitor);
     }
 
     public static void applySelectedVideoMode() {
@@ -92,5 +95,24 @@ public abstract class VideoModeManager {
         }
 
         return null;
+    }
+
+    public static Long[] populateMonitors(){
+        List<Long> monitors = new ArrayList<>();
+
+        var monitors_raw = glfwGetMonitors();
+        for (int i = 0; i<monitors_raw.limit(); i++){
+            var m = monitors_raw.get(i);
+            monitors.add(m);
+        }
+
+        Long[] arr = new Long[monitors.size()];
+        monitors.toArray(arr);
+
+        return arr;
+    }
+
+    public static Long[] getMonitors(){
+        return monitors;
     }
 }

--- a/src/main/java/net/vulkanmod/config/video/VideoModeManager.java
+++ b/src/main/java/net/vulkanmod/config/video/VideoModeManager.java
@@ -125,4 +125,8 @@ public abstract class VideoModeManager {
         videoModeSets = populateVideoResolutions(selectedMonitor);
         selectedVideoMode = getFirstAvailable().getVideoMode();
     }
+
+    public static void applySelectedMonitor() {
+        Initializer.CONFIG.monitor = glfwGetMonitorName(selectedMonitor);
+    }
 }

--- a/src/main/java/net/vulkanmod/config/video/VideoModeManager.java
+++ b/src/main/java/net/vulkanmod/config/video/VideoModeManager.java
@@ -96,12 +96,12 @@ public abstract class VideoModeManager {
         return null;
     }
 
-    public static Long[] populateMonitors(){
+    public static Long[] populateMonitors() {
         List<Long> monitors = new ArrayList<>();
 
-        var monitors_raw = glfwGetMonitors();
-        for (int i = 0; i<monitors_raw.limit(); i++){
-            var m = monitors_raw.get(i);
+        var monitorsRaw = glfwGetMonitors();
+        for (int i = 0; i < monitorsRaw.limit(); i++) {
+            var m = monitorsRaw.get(i);
             monitors.add(m);
         }
 
@@ -111,7 +111,7 @@ public abstract class VideoModeManager {
         return arr;
     }
 
-    public static Long[] getMonitors(){
+    public static Long[] getMonitors() {
         return monitors;
     }
 
@@ -119,7 +119,7 @@ public abstract class VideoModeManager {
         return selectedMonitor;
     }
 
-    public static void setSelectedMonitor(long new_monitor){
+    public static void setSelectedMonitor(long new_monitor) {
         selectedMonitor = new_monitor;
         osVideoMode = getCurrentVideoMode(selectedMonitor);
         videoModeSets = populateVideoResolutions(selectedMonitor);

--- a/src/main/java/net/vulkanmod/mixin/window/WindowMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/window/WindowMixin.java
@@ -128,7 +128,7 @@ public abstract class WindowMixin {
     private void setMode() {
         Config config = Initializer.CONFIG;
 
-        long monitor = GLFW.glfwGetPrimaryMonitor();
+        long monitor = VideoModeManager.selectedMonitor;
         if (this.fullscreen) {
             {
                 VideoModeSet.VideoMode videoMode = config.videoMode;

--- a/src/main/java/net/vulkanmod/mixin/window/WindowMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/window/WindowMixin.java
@@ -24,8 +24,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Objects;
-
 import static org.lwjgl.glfw.GLFW.*;
 
 @Mixin(Window.class)
@@ -130,18 +128,20 @@ public abstract class WindowMixin {
     private void setMode() {
         Config config = Initializer.CONFIG;
 
+        // Try to recover a monitor pointer
         long monitor = 0;
-        for (var m : VideoModeManager.getMonitors()){
+        for (var m : VideoModeManager.getMonitors()) {
             var name = glfwGetMonitorName(m);
-            if (name.equals(config.monitor)){
+            if (name.equals(config.monitor)) {
                 monitor = m;
                 break;
             }
         }
-        if(monitor == 0){
+        // if the save monitor is not present / there was no saved monitor fallback
+        if (monitor == 0) {
             monitor = glfwGetPrimaryMonitor();
         }
-        VideoModeManager.setSelectedMonitor(monitor);
+        VideoModeManager.setSelectedMonitor(monitor); // refresh video mode manager
         if (this.fullscreen) {
             {
                 VideoModeSet.VideoMode videoMode = config.videoMode;

--- a/src/main/java/net/vulkanmod/mixin/window/WindowMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/window/WindowMixin.java
@@ -24,6 +24,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.Objects;
+
 import static org.lwjgl.glfw.GLFW.*;
 
 @Mixin(Window.class)
@@ -128,7 +130,18 @@ public abstract class WindowMixin {
     private void setMode() {
         Config config = Initializer.CONFIG;
 
-        long monitor = VideoModeManager.getSelectedMonitor();
+        long monitor = 0;
+        for (var m : VideoModeManager.getMonitors()){
+            var name = glfwGetMonitorName(m);
+            if (name.equals(config.monitor)){
+                monitor = m;
+                break;
+            }
+        }
+        if(monitor == 0){
+            monitor = glfwGetPrimaryMonitor();
+        }
+        VideoModeManager.setSelectedMonitor(monitor);
         if (this.fullscreen) {
             {
                 VideoModeSet.VideoMode videoMode = config.videoMode;

--- a/src/main/java/net/vulkanmod/mixin/window/WindowMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/window/WindowMixin.java
@@ -128,7 +128,7 @@ public abstract class WindowMixin {
     private void setMode() {
         Config config = Initializer.CONFIG;
 
-        long monitor = VideoModeManager.selectedMonitor;
+        long monitor = VideoModeManager.getSelectedMonitor();
         if (this.fullscreen) {
             {
                 VideoModeSet.VideoMode videoMode = config.videoMode;

--- a/src/main/resources/assets/vulkanmod/lang/en_us.json
+++ b/src/main/resources/assets/vulkanmod/lang/en_us.json
@@ -44,5 +44,7 @@
   "vulkanmod.options.windowMode.windowedFullscreen": "Windowed Fullscreen",
 
   "vulkanmod.options.builderThreads": "Chunk Builder Threads",
-  "vulkanmod.options.builderThreads.auto": "Auto"
+  "vulkanmod.options.builderThreads.auto": "Auto",
+
+  "vulkanmod.options.monitor": "Monitor"
 }


### PR DESCRIPTION
Added the option to switch from the default monitor picked up by GLFW. This is useful in multi-monitor setups, especially when GLFW defaults to an undesirable monitor.