### PR TITLE
Added a system property to skip wayland compatibility patches

### DIFF
--- a/src/main/java/net/vulkanmod/config/Platform.java
+++ b/src/main/java/net/vulkanmod/config/Platform.java
@@ -10,6 +10,7 @@ import static org.lwjgl.glfw.GLFW.*;
 public abstract class Platform {
     private static final int activePlat = getSupportedPlat();
     private static final String activeDE = determineDE();
+    public static final boolean skipWaylandPatches = shouldSkipWaylandPatches();
 
     public static void init() {
         // Increase stack size to 256 KB to prevent out of stack error on nvidia driver
@@ -63,6 +64,11 @@ public abstract class Platform {
             return xdgCurrentDesktop.toLowerCase();
         return "N/A";
     }
+
+    private static boolean shouldSkipWaylandPatches() {
+        return System.getProperties().containsKey("vkmod.wayland.compat.skip");
+    }
+
 
     public static int getActivePlat() {
         return activePlat;

--- a/src/main/java/net/vulkanmod/config/Platform.java
+++ b/src/main/java/net/vulkanmod/config/Platform.java
@@ -10,7 +10,6 @@ import static org.lwjgl.glfw.GLFW.*;
 public abstract class Platform {
     private static final int activePlat = getSupportedPlat();
     private static final String activeDE = determineDE();
-    public static final boolean skipWaylandPatches = shouldSkipWaylandPatches();
 
     public static void init() {
         // Increase stack size to 256 KB to prevent out of stack error on nvidia driver
@@ -65,10 +64,9 @@ public abstract class Platform {
         return "N/A";
     }
 
-    private static boolean shouldSkipWaylandPatches() {
+    public static boolean shouldSkipWaylandPatches() {
         return System.getProperties().containsKey("vkmod.wayland.compat.skip");
     }
-
 
     public static int getActivePlat() {
         return activePlat;

--- a/src/main/java/net/vulkanmod/mixin/wayland/InputConstantsM.java
+++ b/src/main/java/net/vulkanmod/mixin/wayland/InputConstantsM.java
@@ -15,7 +15,7 @@ public class InputConstantsM {
      */
     @Redirect(method = "grabOrReleaseMouse", at = @At(value = "INVOKE", target = "Lorg/lwjgl/glfw/GLFW;glfwSetCursorPos(JDD)V"))
     private static void grabOrReleaseMouse(long window, double xpos, double ypos) {
-        if (!Platform.isWayLand())
+        if (Platform.skipWaylandPatches || !Platform.isWayLand())
             GLFW.glfwSetCursorPos(window, xpos, ypos);
     }
 }

--- a/src/main/java/net/vulkanmod/mixin/wayland/InputConstantsM.java
+++ b/src/main/java/net/vulkanmod/mixin/wayland/InputConstantsM.java
@@ -15,7 +15,7 @@ public class InputConstantsM {
      */
     @Redirect(method = "grabOrReleaseMouse", at = @At(value = "INVOKE", target = "Lorg/lwjgl/glfw/GLFW;glfwSetCursorPos(JDD)V"))
     private static void grabOrReleaseMouse(long window, double xpos, double ypos) {
-        if (Platform.skipWaylandPatches || !Platform.isWayLand())
+        if (Platform.shouldSkipWaylandPatches() || !Platform.isWayLand())
             GLFW.glfwSetCursorPos(window, xpos, ypos);
     }
 }

--- a/src/main/java/net/vulkanmod/mixin/wayland/MinecraftMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/wayland/MinecraftMixin.java
@@ -31,7 +31,7 @@ public class MinecraftMixin {
      */
     @Redirect(method="<init>", at=@At(value="INVOKE", target="Lcom/mojang/blaze3d/platform/Window;setIcon(Lnet/minecraft/server/packs/PackResources;Lcom/mojang/blaze3d/platform/IconSet;)V"))
     private void bypassWaylandIcon(Window instance, PackResources packResources, IconSet iconSet) throws IOException {
-        if (Platform.skipWaylandPatches || !Platform.isWayLand())
+        if (Platform.shouldSkipWaylandPatches() || !Platform.isWayLand())
         {
             this.window.setIcon(this.vanillaPackResources, SharedConstants.getCurrentVersion().stable() ? IconSet.RELEASE : IconSet.SNAPSHOT);
         }

--- a/src/main/java/net/vulkanmod/mixin/wayland/MinecraftMixin.java
+++ b/src/main/java/net/vulkanmod/mixin/wayland/MinecraftMixin.java
@@ -31,7 +31,7 @@ public class MinecraftMixin {
      */
     @Redirect(method="<init>", at=@At(value="INVOKE", target="Lcom/mojang/blaze3d/platform/Window;setIcon(Lnet/minecraft/server/packs/PackResources;Lcom/mojang/blaze3d/platform/IconSet;)V"))
     private void bypassWaylandIcon(Window instance, PackResources packResources, IconSet iconSet) throws IOException {
-        if (!Platform.isWayLand())
+        if (Platform.skipWaylandPatches || !Platform.isWayLand())
         {
             this.window.setIcon(this.vanillaPackResources, SharedConstants.getCurrentVersion().stable() ? IconSet.RELEASE : IconSet.SNAPSHOT);
         }


### PR DESCRIPTION
Added system property "vkmod.wayland.compat.skip" that when set, disables patches by VulkanMod that are made to prevent errors and crashes when running under Wayland, the reason for this is to enable advanced users to provide their own patched versions of `libglfw.so` that adds native support for Wayland, fixing these crashes outside of the context of this mod.

Wayland users can set `-Dorg.lwjgl.glfw.libname=/path/to/custom/glfw/libglfw.so` and `-Dvkmod.wayland.compat.skip` to enable full Wayland compatibility, provided they use [this patched version of libglfw](https://github.com/BoyOrigin/glfw-wayland), fixing many bugs when running under Wayland.