### PR TITLE
Fix one memory leak

### DIFF
--- a/src/main/java/net/vulkanmod/vulkan/shader/DescriptorSets.java
+++ b/src/main/java/net/vulkanmod/vulkan/shader/DescriptorSets.java
@@ -25,8 +25,8 @@ public class DescriptorSets {
 
     private final Pipeline pipeline;
     private int poolSize = 10;
-    private long descriptorPool;
-    private LongBuffer sets;
+    private long descriptorPool = VK_NULL_HANDLE;
+    private long[] sets;
     private long currentSet;
     private int currentIdx = -1;
 
@@ -149,7 +149,7 @@ public class DescriptorSets {
         // Check pool size
         checkPoolSize(stack);
 
-        this.currentSet = this.sets.get(this.currentIdx);
+        this.currentSet = this.sets[this.currentIdx];
 
         VkWriteDescriptorSet.Buffer descriptorWrites = VkWriteDescriptorSet.calloc(pipeline.buffers.size() + pipeline.imageDescriptors.size(), stack);
         VkDescriptorBufferInfo.Buffer[] bufferInfos = new VkDescriptorBufferInfo.Buffer[pipeline.buffers.size()];
@@ -229,7 +229,8 @@ public class DescriptorSets {
         allocInfo.descriptorPool(descriptorPool);
         allocInfo.pSetLayouts(layout);
 
-        this.sets = MemoryUtil.memAllocLong(this.poolSize);
+        // Not hotspot code, use heap array
+        this.sets = new long[this.poolSize];
 
         int result = vkAllocateDescriptorSets(DEVICE, allocInfo, this.sets);
         if (result != VK_SUCCESS) {


### PR DESCRIPTION
Old code would never free the VkHandle off-heap array (the one allocated with je_malloc). Now use heap array instead since it's not hotspot code, JNI performs to-heap copy