### PR TITLE
Improve device vendor string detection

### DIFF
--- a/src/main/java/net/vulkanmod/vulkan/device/Device.java
+++ b/src/main/java/net/vulkanmod/vulkan/device/Device.java
@@ -72,7 +72,8 @@ public class Device {
     private static String decodeVendor(int i) {
         return switch (i) {
             case (0x10DE) -> "Nvidia";
-            case (0x1022) -> "AMD";
+            // AMD has two deviceIds, apparently
+            case (0x1022), (0x1002) -> "AMD";
             case (0x8086) -> "Intel";
             default -> "undef"; //Either AMD or Unknown Driver version/vendor and.or Encoding Scheme
         };
@@ -90,7 +91,7 @@ public class Device {
     private static String decodeDvrVersion(int v, int i) {
         return switch (i) {
             case (0x10DE) -> decodeNvidia(v); //Nvidia
-            case (0x1022) -> decDefVersion(v); //AMD
+            case (0x1022), (0x1002) -> decDefVersion(v); //AMD
             case (0x8086) -> decIntelVersion(v); //Intel
             default -> decDefVersion(v); //Either AMD or Unknown Driver Encoding Scheme
         };
@@ -149,7 +150,7 @@ public class Device {
     // Added these to allow detecting GPU vendor, to allow handling vendor specific circumstances:
     // (e.g. such as in case we encounter a vendor specific driver bug)
     public boolean isAMD() {
-        return vendorId == 0x1022;
+        return vendorId == 0x1022 || vendorId == 0x1002;
     }
 
     public boolean isNvidia() {

--- a/src/main/java/net/vulkanmod/vulkan/device/Device.java
+++ b/src/main/java/net/vulkanmod/vulkan/device/Device.java
@@ -72,9 +72,15 @@ public class Device {
     private static String decodeVendor(int i) {
         return switch (i) {
             case (0x10DE) -> "Nvidia";
-            // AMD has two deviceIds, apparently
-            case (0x1022), (0x1002) -> "AMD";
+            case (0x1022), (0x1002) -> "AMD"; // AMD has two deviceIds, apparently
             case (0x8086) -> "Intel";
+            case (0x1010) -> "Imagination Technologies";
+            case (0x13B5) -> "ARM";
+            case (0x5143) -> "Qualcomm";
+            case (0x106B) -> "Apple";
+            case (0x14E4) -> "Broadcom";
+            case (0x1AE0) -> "Google"; // Not sure about this, SwiftShader devices have this id
+            case (0x10005) -> "Mesa"; // Honeykrisp on Apple devices has this vendorId for some reason
             default -> "undef"; //Either AMD or Unknown Driver version/vendor and.or Encoding Scheme
         };
     }


### PR DESCRIPTION
Current code supports only AMD/NVIDIA/Intel, additionally, AMD has broken id not present on most modern AMD GPUs. This pull request:
* Fixes AMD vendorId - `0x1002`. Though, I'm not sure if `0x1022` is valid too, so I left it in place as well.
* Adds vendorId decoding for less common Vulkan devices such as Apple & Qualcomm. You may say VulkanMod doesn't support non-PC platforms (i.e. Android), however, SBCs with these 3D accelerators do exist. Additionally, Apple & Qualcomm are present on the consumer PC market.