### PR TITLE
Use correct rendering device name for Blaze3D

### DIFF
--- a/src/main/java/net/vulkanmod/render/engine/VkGpuDevice.java
+++ b/src/main/java/net/vulkanmod/render/engine/VkGpuDevice.java
@@ -197,7 +197,7 @@ public class VkGpuDevice implements GpuDevice {
 
     @Override
     public String getVersion() {
-        return Vulkan.getDevice().vkVersion;
+        return String.format("%s (VulkanMod %s)", Vulkan.getDevice().vkVersion, Initializer.getVersion());
     }
 
     private static int getMaxSupportedTextureSize() {

--- a/src/main/java/net/vulkanmod/render/engine/VkGpuDevice.java
+++ b/src/main/java/net/vulkanmod/render/engine/VkGpuDevice.java
@@ -182,7 +182,7 @@ public class VkGpuDevice implements GpuDevice {
 
     @Override
     public String getRenderer() {
-        return "VulkanMod %s".formatted(Initializer.getVersion()) ;
+        return Vulkan.getDevice().deviceName;
     }
 
     @Override


### PR DESCRIPTION
Replace VulkanMod version string with the rendering device name. This brings used GPU name in F3/Debug HUD back.

I've moved the VulkanMod string down to the API version. Still not sure if it's a correct choice, let me know if it's not!

Looks like this now:
<img width="371" height="117" alt="image" src="https://github.com/user-attachments/assets/0328eb16-4a8c-42c2-b1bb-c6bc109f4a45" />
