### PR TITLE
Fix incorrect handling of VkResult in swapchain creation

### DIFF
--- a/src/main/java/net/vulkanmod/vulkan/Vulkan.java
+++ b/src/main/java/net/vulkanmod/vulkan/Vulkan.java
@@ -381,7 +381,7 @@ public class Vulkan {
     }
 
     public static void checkResult(int result, String errorMessage) {
-        if (result != VK_SUCCESS) {
+        if (result < VK_SUCCESS) {
             throw new RuntimeException(String.format("%s: %s", errorMessage, VkResult.decode(result)));
         }
     }


### PR DESCRIPTION
Hi,
I ran into some problems running this mod on my wayland linux setup and after some investigation it turned out the error handling of VkResult is incorrect.
Basically in Vulkan.java the checkResult function:
```java
public static void checkResult(int result, String errorMessage) {
  if (result != VK_SUCCESS) {
    throw new RuntimeException(String.format("%s: %s", errorMessage, VkResult.decode(result)));
  }
}
```
should be changed to 
```java
public static void checkResult(int result, String errorMessage) {
  if (result < VK_SUCCESS) {  // Change to <
    throw new RuntimeException(String.format("%s: %s", errorMessage, VkResult.decode(result)));
   }
}
```
Fixes:
https://github.com/xCollateral/VulkanMod/issues/791
https://github.com/xCollateral/VulkanMod/issues/724
https://github.com/xCollateral/VulkanMod/issues/708

This prevents fatal crashes on many linux setups. VkResult codes like VK_SUBOPTIMAL_KHR or VK_TIMEOUT should NOT be treated as fatal according to the vulkan spec.
Fatal errors return negative values, while non-fatal errors return positive values.
Ref: 
https://docs.vulkan.org/refpages/latest/refpages/source/vkCreateSwapchainKHR.html
https://docs.vulkan.org/refpages/latest/refpages/source/VkResult.html

Tested on multiple setups, this is the correct behavior and "fixes" non-fatal errors being treated as crashes.
Errors like temporary out of date errors will resolve without crashing (e.g. resizing a window, losing window focus, etc.).