### PR TITLE
Fix crash on immediate vertex batches larger than staging buffer

### DIFF
--- a/src/main/java/net/vulkanmod/render/engine/VkCommandEncoder.java
+++ b/src/main/java/net/vulkanmod/render/engine/VkCommandEncoder.java
@@ -290,6 +290,14 @@ public class VkCommandEncoder implements CommandEncoder {
                     var commandBuffer = Renderer.getInstance().getTransferCb();
 
                     StagingBuffer stagingBuffer = Vulkan.getStagingBuffer();
+
+                    // Large immediate batches (e.g. many entities sharing one RenderType) can
+                    // exceed the default staging buffer; fall back to a one-shot oversized buffer.
+                    if (size > stagingBuffer.getBufferSize()) {
+                        stagingBuffer = new StagingBuffer(size);
+                        stagingBuffer.scheduleFree();
+                    }
+
                     stagingBuffer.copyBuffer(size, byteBuffer);
 
                     long srcOffset = stagingBuffer.getOffset();


### PR DESCRIPTION
Fix for the bug reported here: https://discord.com/channels/963180553547419670/1291872109190189066

Reproduction: spawn a lot of villagers in creative; once enough of them are on screen, the client crashes with `IllegalArgumentException: Upload size is greater than staging buffer size.` from `StagingBuffer.copyBuffer`.

## Cause

When many entities share the same `RenderType`, `MultiBufferSource.BufferSource.endBatch` flushes a single immediate vertex buffer that can exceed the default 64 MiB staging buffer. `VkCommandEncoder.writeToBuffer` then calls `StagingBuffer.copyBuffer(size, byteBuffer)`, which throws because `size > bufferSize`.

Full crash trace from the user report:

```
java.lang.IllegalArgumentException: Upload size is greater than staging buffer size.
    at net.vulkanmod.vulkan.memory.buffer.StagingBuffer.copyBuffer(StagingBuffer.java:34)
    at net.vulkanmod.vulkan.memory.buffer.StagingBuffer.copyBuffer(StagingBuffer.java:29)
    at net.vulkanmod.render.engine.VkCommandEncoder.writeToBuffer(VkCommandEncoder.java:296)
    at net.vulkanmod.render.engine.VkGpuDevice.createBuffer(VkGpuDevice.java:174)
    at com.mojang.blaze3d.systems.GpuDevice.createBuffer(GpuDevice.java:117)
    at com.mojang.blaze3d.vertex.VertexFormat.uploadToBuffer(VertexFormat.java:121)
    at com.mojang.blaze3d.vertex.VertexFormat.uploadImmediateVertexBuffer(VertexFormat.java:130)
    at net.minecraft.client.renderer.rendertype.RenderType.draw(RenderType.java:575)
    at net.minecraft.client.renderer.MultiBufferSource$BufferSource.endBatch(MultiBufferSource.java:96)
    ...
    at net.minecraft.client.renderer.feature.ModelFeatureRenderer.renderBatch(ModelFeatureRenderer.java:58)
    at net.minecraft.client.renderer.feature.FeatureRenderDispatcher.renderSolidFeatures(FeatureRenderDispatcher.java:47)
```

## Sketch fix

Mirror the same idiom that `VulkanImage.uploadSubTextureAsync` already uses for oversized texture uploads: if the upload does not fit, allocate a one-shot oversized `StagingBuffer` and let `scheduleFree()` reclaim it after the current frame.

```java
StagingBuffer stagingBuffer = Vulkan.getStagingBuffer();

if (size > stagingBuffer.getBufferSize()) {
    stagingBuffer = new StagingBuffer(size);
    stagingBuffer.scheduleFree();
}

stagingBuffer.copyBuffer(size, byteBuffer);
```

## Disclaimer

This fix was written by Claude Code — I'm too lazy to dig into the rendering side myself, so treat this as a rough sketch rather than a polished patch. Feel free to take it just as an example and write your own proper fix; my goal here is only to point at the root cause and provide a starting point.

There may be other call sites that should get the same defensive treatment (e.g. `IndirectBuffer.recordCopyCmd`, `MemoryTypes.DeviceLocalMemory.copyToBuffer`) — they call `StagingBuffer.copyBuffer` directly too, although they are unlikely to hit it under normal use.