### PR TITLE
[Feature] Added FMJ Entrypoint For Mod Settings Registry

### DIFF
--- a/src/main/java/net/vulkanmod/config/api/VkModSettingsEntryBuilder.java
+++ b/src/main/java/net/vulkanmod/config/api/VkModSettingsEntryBuilder.java
@@ -1,0 +1,64 @@
+package net.vulkanmod.config.api;
+
+import net.minecraft.network.chat.FormattedText;
+import net.minecraft.resources.Identifier;
+import net.vulkanmod.config.api.page.VkPageOptionsBuilder;
+import net.vulkanmod.config.api.page.VkPagesBuilder;
+import net.vulkanmod.config.gui.ModSettingsEntry;
+import net.vulkanmod.config.option.OptionPage;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+public class VkModSettingsEntryBuilder {
+    private FormattedText modName;
+    private Supplier<Identifier> iconSupplier;
+    private Supplier<List<OptionPage>> optionPageSupplier;
+    private Runnable onApply;
+    private final VkPagesBuilder pageBuilder = new VkPagesBuilder();
+
+    private Supplier<List<OptionPage>> getOptionPageSupplier() {
+        if (optionPageSupplier != null) {
+            return optionPageSupplier;
+        }
+        return this.pageBuilder::build;
+    }
+
+    public VkModSettingsEntryBuilder setModName(FormattedText modName) {
+        this.modName = modName;
+        return this;
+    }
+
+    public VkModSettingsEntryBuilder setIcon(Identifier icon) {
+        this.iconSupplier = () -> icon;
+        return this;
+    }
+
+    public VkModSettingsEntryBuilder setIconSupplier(Supplier<Identifier> iconSupplier) {
+        this.iconSupplier = iconSupplier;
+        return this;
+    }
+
+    public VkModSettingsEntryBuilder setOptionPageSupplier(Supplier<List<OptionPage>> optionPageSupplier) {
+        this.optionPageSupplier = optionPageSupplier;
+        return this;
+    }
+
+    public VkPageOptionsBuilder withPage(String name) {
+        return pageBuilder.withPage(name, this);
+    }
+
+    public VkModSettingsEntryBuilder setOnApply(Runnable onApply) {
+        this.onApply = onApply;
+        return this;
+    }
+
+    public ModSettingsEntry build() {
+        return new ModSettingsEntry(
+                modName,
+                iconSupplier,
+                getOptionPageSupplier(),
+                onApply
+        );
+    }
+}

--- a/src/main/java/net/vulkanmod/config/api/VkModSettingsFactory.java
+++ b/src/main/java/net/vulkanmod/config/api/VkModSettingsFactory.java
@@ -1,0 +1,7 @@
+package net.vulkanmod.config.api;
+
+import net.vulkanmod.config.gui.ModSettingsEntry;
+
+public interface VkModSettingsFactory {
+    ModSettingsEntry build(VkModSettingsEntryBuilder builder);
+}

--- a/src/main/java/net/vulkanmod/config/api/page/VkOptionsBuilder.java
+++ b/src/main/java/net/vulkanmod/config/api/page/VkOptionsBuilder.java
@@ -1,0 +1,30 @@
+package net.vulkanmod.config.api.page;
+
+import net.vulkanmod.config.option.Option;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class VkOptionsBuilder {
+    private final VkPageOptionsBuilder parent;
+    private final List<Option<?>> options = new ArrayList<>();
+
+    public VkOptionsBuilder(VkPageOptionsBuilder parent) {
+        this.parent = parent;
+    }
+
+    public <T> VkOptionsBuilder addOption(Option<T> option) {
+        options.add(option);
+        return this;
+    }
+
+    public VkPageOptionsBuilder finish() {
+         return parent;
+    }
+
+    public Option<?>[] build() {
+        Option<?>[] optionsArray = new Option<?>[options.size()];
+        options.toArray(optionsArray);
+        return optionsArray;
+    }
+}

--- a/src/main/java/net/vulkanmod/config/api/page/VkPageOptionsBuilder.java
+++ b/src/main/java/net/vulkanmod/config/api/page/VkPageOptionsBuilder.java
@@ -1,0 +1,39 @@
+package net.vulkanmod.config.api.page;
+
+import net.vulkanmod.config.api.VkModSettingsEntryBuilder;
+import net.vulkanmod.config.gui.OptionBlock;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class VkPageOptionsBuilder {
+    private final VkModSettingsEntryBuilder parent;
+    private final Map<String, VkOptionsBuilder> optionBlockBuilders = new LinkedHashMap<>();
+
+    public VkPageOptionsBuilder(VkModSettingsEntryBuilder parent) {
+        this.parent = parent;
+    }
+
+    public VkOptionsBuilder withOptionBlock(String name) {
+        VkOptionsBuilder builder = new VkOptionsBuilder(this);
+        optionBlockBuilders.put(name, builder);
+        return builder;
+    }
+
+    public VkModSettingsEntryBuilder finish() {
+        return parent;
+    }
+
+    public OptionBlock[] build() {
+        final OptionBlock[] blocks = new OptionBlock[optionBlockBuilders.size()];
+        int i = 0;
+        for (Map.Entry<String, VkOptionsBuilder> entry : optionBlockBuilders.entrySet()) {
+            blocks[i] = new OptionBlock(
+                    entry.getKey(),
+                    entry.getValue().build()
+            );
+            i++;
+        }
+        return blocks;
+    }
+}

--- a/src/main/java/net/vulkanmod/config/api/page/VkPagesBuilder.java
+++ b/src/main/java/net/vulkanmod/config/api/page/VkPagesBuilder.java
@@ -1,0 +1,30 @@
+package net.vulkanmod.config.api.page;
+
+import net.vulkanmod.config.api.VkModSettingsEntryBuilder;
+import net.vulkanmod.config.option.OptionPage;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class VkPagesBuilder {
+    private final Map<String, VkPageOptionsBuilder> pageBuilders = new LinkedHashMap<>();
+
+    public VkPageOptionsBuilder withPage(String name, VkModSettingsEntryBuilder parent) {
+        VkPageOptionsBuilder builder = new VkPageOptionsBuilder(parent);
+        pageBuilders.put(name, builder);
+        return builder;
+    }
+
+    public List<OptionPage> build() {
+        final List<OptionPage> pages = new ArrayList<>();
+        for (Map.Entry<String, VkPageOptionsBuilder> entry : pageBuilders.entrySet()) {
+            pages.add(new OptionPage(
+                    entry.getKey(),
+                    entry.getValue().build()
+            ));
+        }
+        return pages;
+    }
+}

--- a/src/main/java/net/vulkanmod/config/gui/ModSettingsRegistry.java
+++ b/src/main/java/net/vulkanmod/config/gui/ModSettingsRegistry.java
@@ -1,16 +1,20 @@
 package net.vulkanmod.config.gui;
 
 import it.unimi.dsi.fastutil.objects.ObjectArraySet;
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.vulkanmod.Initializer;
+import net.vulkanmod.config.api.VkModSettingsEntryBuilder;
+import net.vulkanmod.config.api.test.VkModSettingsFactoryImpl;
 import net.vulkanmod.config.option.Options;
 
 import java.util.Set;
 
 public class ModSettingsRegistry {
+    private static final String CONFIG_ENTRY_POINT_KEY = "vulkanmod:mod_settings_registry";
 
     public static final ModSettingsRegistry INSTANCE = new ModSettingsRegistry();
 
@@ -22,6 +26,15 @@ public class ModSettingsRegistry {
                                                                   Options::getOptionPages,
                                                                   () -> Initializer.CONFIG.write());
         this.addModEntry(vulkanModSettings);
+
+        // build and add vulkanmod settings entrypoints
+        var entryPointContainers = FabricLoader.getInstance().getEntrypointContainers(CONFIG_ENTRY_POINT_KEY, VkModSettingsFactoryImpl.class);
+        for (EntrypointContainer<VkModSettingsFactoryImpl> entryPointContainer : entryPointContainers) {
+            VkModSettingsFactoryImpl modSettingsFactory = entryPointContainer.getEntrypoint();
+            VkModSettingsEntryBuilder builder = new VkModSettingsEntryBuilder();
+
+            this.addModEntry(modSettingsFactory.build(builder));
+        }
     }
 
     public void addModEntry(ModSettingsEntry entry) {

--- a/src/main/java/net/vulkanmod/config/gui/ModSettingsRegistry.java
+++ b/src/main/java/net/vulkanmod/config/gui/ModSettingsRegistry.java
@@ -8,7 +8,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.vulkanmod.Initializer;
 import net.vulkanmod.config.api.VkModSettingsEntryBuilder;
-import net.vulkanmod.config.api.test.VkModSettingsFactoryImpl;
+import net.vulkanmod.config.api.VkModSettingsFactory;
 import net.vulkanmod.config.option.Options;
 
 import java.util.Set;
@@ -28,9 +28,9 @@ public class ModSettingsRegistry {
         this.addModEntry(vulkanModSettings);
 
         // build and add vulkanmod settings entrypoints
-        var entryPointContainers = FabricLoader.getInstance().getEntrypointContainers(CONFIG_ENTRY_POINT_KEY, VkModSettingsFactoryImpl.class);
-        for (EntrypointContainer<VkModSettingsFactoryImpl> entryPointContainer : entryPointContainers) {
-            VkModSettingsFactoryImpl modSettingsFactory = entryPointContainer.getEntrypoint();
+        var entryPointContainers = FabricLoader.getInstance().getEntrypointContainers(CONFIG_ENTRY_POINT_KEY, VkModSettingsFactory.class);
+        for (EntrypointContainer<VkModSettingsFactory> entryPointContainer : entryPointContainers) {
+            VkModSettingsFactory modSettingsFactory = entryPointContainer.getEntrypoint();
             VkModSettingsEntryBuilder builder = new VkModSettingsEntryBuilder();
 
             this.addModEntry(modSettingsFactory.build(builder));


### PR DESCRIPTION
I've added a very simple API for other mods to implement and a custom entrypoint that other mods can add to their `fabric.mod.json` that allows for them to register their own configuration pages to the `ModSettingsRegistry` without having a hard dependency on VulkanMod, here is an example:

1. implement the `VkModSettingsFactory`:

```java
package net.vulkanmod.config.api.test;

import net.minecraft.ChatFormatting;
import net.minecraft.network.chat.Component;
import net.minecraft.resources.Identifier;
import net.vulkanmod.config.api.VkModSettingsEntryBuilder;
import net.vulkanmod.config.api.VkModSettingsFactory;
import net.vulkanmod.config.gui.ModSettingsEntry;
import net.vulkanmod.config.option.CyclingOption;
import net.vulkanmod.config.option.RangeOption;
import net.vulkanmod.config.option.SwitchOption;

public class VkModSettingsFactoryImpl implements VkModSettingsFactory {
    @Override
    public ModSettingsEntry build(VkModSettingsEntryBuilder builder) {
        return builder
                .setModName(Component.literal("Test Mod").withStyle(ChatFormatting.RED))
                .setIcon(Identifier.fromNamespaceAndPath("test-mod", "icon.png"))
                .withPage("Test Page")
                    .withOptionBlock("Test Block")
                        .addOption(new SwitchOption(
                                Component.literal("Test SwitchOption"),
                                (v) -> {},
                                () -> false
                        ))
                        .addOption(
                                new CyclingOption<ChatFormatting>(
                                        Component.literal("Test CyclingOption"),
                                        ChatFormatting.values(),
                                        (v) -> {},
                                        () -> ChatFormatting.RESET
                                ).setTranslator((v) -> Component.literal(v.name()).withStyle(v))
                        )
                        .addOption(new RangeOption(
                                Component.literal("Test RangeOption"),
                                0,
                                100,
                                1,
                                (v) -> {},
                                () -> 0
                        ))
                        .finish()
                    .withOptionBlock("Test Empty Block")
                        .finish()
                .finish()
                .withPage("Test Page 2")
                    .withOptionBlock("Test Empty Block")
                        .finish()
                .finish()
                .setOnApply(() -> {
                    // save configuration
                })
                .build();
    }
}
```

2. add the class `VkModSettingsFactoryImpl` to the fabric.mod.json:

```json
... other fields
"entrypoints": {
    "vulkanmod:mod_settings_registry": [
        "net.vulkanmod.config.api.test.VkModSettingsFactoryImpl"
    ]
}
... other fields
```

it will be loaded and added to the mod registry automatically (when VulkanMod exists) and will not do anything when VulkanMod is not present, allowing other mods to register their own `ModSettingsEntry` without having a hard dependency on VulkanMod.