### PR TITLE
[Fix] Issues in Video Option Screen

### DIFF
--- a/src/main/java/net/vulkanmod/config/gui/widget/ModIconWidget.java
+++ b/src/main/java/net/vulkanmod/config/gui/widget/ModIconWidget.java
@@ -1,7 +1,9 @@
 package net.vulkanmod.config.gui.widget;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
 import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.client.sounds.SoundManager;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.FormattedText;
 import net.minecraft.resources.Identifier;
@@ -22,6 +24,10 @@ public class ModIconWidget extends VAbstractWidget {
         this.height = height;
     }
 
+    @Override
+    public void playDownSound(SoundManager soundManager) {
+    }
+
     public void render(double mX, double mY) {
         int backgroundColor = ColorUtil.ARGB.multiplyAlpha(VGuiConstants.COLOR_BLACK, 0.6f);
         int width = this.width;
@@ -29,12 +35,15 @@ public class ModIconWidget extends VAbstractWidget {
         GuiRenderer.fill(this.x, this.y, this.x + width, this.y + height, backgroundColor);
 
 
-        int size = this.height - 4;
+        int iconSize = this.height - 4;
         int iconX = this.x + 4;
-        int iconY = this.y + (height - size) / 2;
-        GuiRenderer.guiGraphics.blit(RenderPipelines.GUI_TEXTURED, icon, iconX, iconY, 0f, 0f, size, size, size, size);
+        int iconY = this.y + (height - iconSize) / 2;
+        GuiRenderer.guiGraphics.blit(RenderPipelines.GUI_TEXTURED, icon, iconX, iconY, 0f, 0f, iconSize, iconSize, iconSize, iconSize);
+        Font textRenderer = Minecraft.getInstance().font;
 
-        size = this.height;
-        GuiRenderer.drawString(Minecraft.getInstance().font, (Component) this.name, this.x + 6 + size, this.y + this.height / 2 - 4, 0xffffffff);
+        int size = this.height;
+        int maxWidth = this.width - iconSize - 8;
+
+        GuiRenderer.drawScrollingString(textRenderer, (Component) this.name, this.x + size + maxWidth / 2 + 3, this.y + this.height / 2 - 4, maxWidth - 4, 0xffffffff);
     }
 }


### PR DESCRIPTION
Fixes two bugs in the video option screen:

1. Clicking on the mod name/icon has a clicking sound but does nothing
2. if the mod's name is too long, it extends outside of the area assigned to the `ModIconWidget`

for the second issue, I've made the text pan to left and right (animation based on system time) and used scissors so the text wont exceed the boundaries assigned to  `ModIconWidget`

Before:
<img width="295" height="181" alt="image" src="https://github.com/user-attachments/assets/48eca8fe-bd30-4276-9597-22ba9c101037" />

After:
<img width="295" height="181" alt="Screenshot From 2026-06-07 22-34-56" src="https://github.com/user-attachments/assets/22560bf9-8d1b-4285-85e0-3f0becbbaf4a" />
