### PR TITLE
Fix crash on renderbuffers with no sampler filter (#674)

### DIFF
--- a/src/main/java/net/vulkanmod/gl/VkGlRenderbuffer.java
+++ b/src/main/java/net/vulkanmod/gl/VkGlRenderbuffer.java
@@ -156,6 +156,14 @@ public class VkGlRenderbuffer {
     }
 
     void updateSampler() {
+        // A renderbuffer is a render target, not a sampled resource, so it may
+        // legitimately have no sampler filter set (minFilter == 0, the unset
+        // default). Treat that as "no sampler needed" and skip the sampler
+        // build instead of falling through to the "Unexpected min filter value"
+        // throw below. See issue #674 (Xaero's custom depth renderbuffer FBO).
+        if (minFilter == 0)
+            return;
+
         if (vulkanImage == null)
             return;
 


### PR DESCRIPTION
`VkGlRenderbuffer` treats a GL renderbuffer like a sampled texture and demands a min filter. A renderbuffer is a render target with no sampler, so `minFilter` stays at its unset default of 0 and `updateSampler()` falls through to `throw "Unexpected min filter value: 0"`. Treat `minFilter == 0` as "no sampler needed" and return early.

Triggered in the wild by Xaero's `ImprovedFramebuffer` (issue #674). Confirmed fixed in-game on MC 1.21.1 with Xaero's Minimap / World Map.

Scope note: I originally paired this with a framebuffer deferred-attach guard, but that only turns the crash into wrong-texture map rendering — Xaero's map needs a proper deferred attachment-resolve in `VkGlFramebuffer`, which I'm working on separately. This PR is just the standalone renderbuffer crash fix.
