### PR TITLE
Fix crash when a graphics pipeline is bound with no active render pass

### DIFF
--- a/src/main/java/net/vulkanmod/vulkan/Renderer.java
+++ b/src/main/java/net/vulkanmod/vulkan/Renderer.java
@@ -632,6 +632,14 @@ public class Renderer {
     }
 
     public void bindGraphicsPipeline(GraphicsPipeline pipeline) {
+        // No active render pass, e.g. the GUI still renders while the window is
+        // occluded or the title bar is being dragged. Binding here would build a
+        // PipelineState with a null render pass and NPE in
+        // GraphicsPipeline.createGraphicsPipeline at state.renderPass.getId().
+        // There is nothing to record into without a pass, so skip the bind.
+        if (boundRenderPass == null)
+            return;
+
         VkCommandBuffer commandBuffer = currentCmdBuffer;
 
         PipelineState currentState = PipelineState.getCurrentPipelineState(boundRenderPass);


### PR DESCRIPTION
Fixes an intermittent `NullPointerException` that kills the game when the window is
occluded, minimized, or the title bar is being dragged.

## Symptom

```
java.lang.NullPointerException: Cannot invoke "...RenderPass.getId()" because "state.renderPass" is null
	at net.vulkanmod.vulkan.shader.GraphicsPipeline.createGraphicsPipeline(GraphicsPipeline.java:192)
	at ...Object2LongOpenHashMap.computeIfAbsent (getHandle:58)
	at net.vulkanmod.vulkan.Renderer.bindGraphicsPipeline(Renderer.java:638)
	at net.minecraft.class_5944.bindPipeline(ShaderInstance)
```

## Repro

In-game, open chat, then tab out or minimize the window. Crashes intermittently.

It is a race between three conditions: the window stops having a valid render target,
the GUI (chat) keeps rendering anyway, and a GUI shader is used whose pipeline is not
yet in the cache.

## Cause

The GUI still renders while no render pass is bound. `bindGraphicsPipeline` builds a
`PipelineState` from the current (null) `boundRenderPass`; the first use of an
uncached GUI shader then reaches `createGraphicsPipeline`, which dereferences
`state.renderPass.getId()` and throws. A cached pipeline survives this path, which is
why the crash only shows up when a not-yet-compiled shader happens to be used during
the occluded frames.

## Fix

Skip the bind when no render pass is bound. Without a pass there is no valid target to
record a draw into, so there is nothing useful to do in this method anyway.

This covers the whole path to the NPE:

- `createGraphicsPipeline` has two call sites.
- Site 2, `getHandle`, is only reached from `Renderer.bindGraphicsPipeline`, which this
  guard covers.
- Site 1, the eager compile in the `GraphicsPipeline` constructor, is gated on
  `Pipeline.Builder.renderPass`.

## Notes

One unrelated observation found while tracing this, left alone here: `PipelineState.DEFAULT`
carries a null `renderPass`, so if the constructor's eager-compile path were ever wired up it
would hit the same dereference on non-`DYNAMIC_RENDERING` devices. Not reachable today; happy
to open a separate issue if that is worth tracking.

## Verification

Repro steps above against the patched build: no crash across repeated tab-outs.
