### PR TITLE
Fall back to owning mod's jar when a shader isn't found in VulkanMod'…

### DIFF
--- a/src/main/java/net/vulkanmod/render/shader/ShaderLoadUtil.java
+++ b/src/main/java/net/vulkanmod/render/shader/ShaderLoadUtil.java
@@ -5,6 +5,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.mojang.blaze3d.shaders.ShaderType;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.resources.Identifier;
 import net.vulkanmod.vulkan.shader.SpirvCompiler;
 import org.apache.commons.io.IOUtils;
@@ -12,11 +14,13 @@ import org.apache.commons.io.IOUtils;
 import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public abstract class ShaderLoadUtil {
@@ -127,7 +131,11 @@ public abstract class ShaderLoadUtil {
             }
 
             if (stream == null) {
-                return null;
+                // Not found in VulkanMod's own jar. This RenderPipeline may belong to
+                // another mod (e.g. malilib's custom terrain pipelines used by Litematica),
+                // with its shader bundled in that mod's own jar. Resolve the Identifier's
+                // namespace to its actual owning mod and look there instead of giving up.
+                return getShaderSourceFromOwningMod(resourceLocation, shaderName, shaderExtension);
             }
 
             String source = IOUtils.toString(new BufferedReader(new InputStreamReader(stream)));
@@ -137,6 +145,43 @@ public abstract class ShaderLoadUtil {
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Fallback for {@link #getShaderSource(Identifier, ShaderType)} when a shader isn't
+     * found inside VulkanMod's own jar. Resolves {@code resourceLocation}'s namespace to its
+     * owning mod via Fabric Loader and reads the shader straight from that mod's real
+     * resource root (works the same in a dev environment or a packaged jar), mirroring the
+     * same two-tier {@code path/name.ext} -> {@code path.ext} lookup order used above.
+     */
+    private static String getShaderSourceFromOwningMod(Identifier resourceLocation, String shaderName, String shaderExtension) {
+        String namespace = resourceLocation.getNamespace();
+        String path = resourceLocation.getPath();
+
+        Optional<ModContainer> container = FabricLoader.getInstance().getModContainer(namespace);
+
+        if (container.isEmpty()) {
+            return null;
+        }
+
+        String[] candidates = {
+            "assets/%s/shaders/%s/%s".formatted(namespace, path, shaderName),
+            "assets/%s/shaders/%s%s".formatted(namespace, path, shaderExtension)
+        };
+
+        for (String candidate : candidates) {
+            Optional<Path> found = container.get().findPath(candidate);
+
+            if (found.isPresent() && Files.isRegularFile(found.get())) {
+                try {
+                    return Files.readString(found.get(), StandardCharsets.UTF_8);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        return null;
     }
 
     public static String getShaderSource(String path, ShaderType type) {


### PR DESCRIPTION
## What this fixes
Any mod that registers its own `RenderPipeline` pointing at shaders bundled in *that mod's own jar* fails to render correctly under VulkanMod. Confirmed case: malilib's custom terrain pipelines (`LEGACY_SOLID_TERRAIN_MASA`, etc.), which Litematica uses for schematic rendering  schematics render blank, invisible, or miscolored with VulkanMod enabled, and work fine with the vanilla renderer.

## Root cause
`ShaderLoadUtil.getShaderSource(Identifier, ShaderType)` builds its file path from `resourceLocation.getPath()` only  the namespace half of the Identifier is discarded  and only ever searches inside VulkanMod's own jar (`RESOURCES_PATH` is hardcoded to `/assets/vulkanmod`). So when a pipeline like `malilib:legacy_terrain` needs compiling, this method only looks for `legacy_terrain...` inside VulkanMod's own jar, never finds it (the file actually lives in malilib's jar, at `assets/malilib/shaders/legacy_terrain.vsh`/`.fsh`), returns `null`, and the pipeline fails to build correctly.

This isn't specific to Litematica/malilib  it'll happen for any mod using the standard `RenderPipeline` API with shaders bundled in its own jar, since that's a completely normal, spec-compliant thing to do.

## The fix
When the existing in-jar lookup misses, fall back to resolving the Identifier's namespace to its actual owning mod via Fabric Loader's `ModContainer` API (`FabricLoader.getInstance().getModContainer(namespace)`  `ModContainer#findPath(...)`), and read the shader from that mod's real resource root. This works identically in a dev environment or a packaged jar, and mirrors the same two-tier `path/name.ext` -> `path.ext` lookup order already used for VulkanMod's own shaders, so behavior for VulkanMod's own shaders is completely unchanged the fallback only ever runs on the specific case where the current lookup already returns null.

`FabricLoader` is already a dependency used elsewhere in the codebase (`ModSettingsRegistry`, `Initializer`), so this doesn't introduce anything new.

## Testing
Built and tested against Fabric 1.21.11 + malilib + Litematica (both on their `LTS/1.21.11` branches). Schematics that previously rendered blank/blue with VulkanMod enabled now render correctly, with no change in behavior for VulkanMod's own shaders or other rendering.

I also have a standalone compat-mod version of this same fix (external mixin, for anyone who wants it before this merges) if that's useful context: [litematica-vulkan-shim].

## Diff
Single file changed: `src/main/java/net/vulkanmod/render/shader/ShaderLoadUtil.java` (+46/-1). Patch attached / see commit.